### PR TITLE
CPU, GPU, RAM informations in bug_report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,9 +23,12 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Axos Version:**
+**Desktop (please complete the following information):**
 
-- Version [e.g. 25.06]
+- CPU of your device [e.g. Intel Core i7]
+- GPU of you device [e.g. NVIDIA]
+- Total RAM in your device [e.g. 8GB]
+- AxOS Version [e.g. 26.06]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
Well, I did another commit but turns out you already merged the previous one.

New change:

```md
**Desktop (please complete the following information):**

- CPU of your device [e.g. Intel Core i7]
- GPU of you device [e.g. NVIDIA]
- Total RAM in your device [e.g. 8GB]
- AxOS Version [e.g. 26.06]
```