### PR TITLE
Add CPU temperature support for both Intel and AMD systems

### DIFF
--- a/src/share/sleex/modules/bar/normal/monitor.js
+++ b/src/share/sleex/modules/bar/normal/monitor.js
@@ -191,7 +191,7 @@ export default () => {
                   BarResourceTemp(
                     "CPU Temp",
                     "device_thermostat",
-                    `LANG=C sensors | awk '/^Package id 0/ {printf("%.2f\\n", $4)}'`,
+                    `LANG=C sensors | awk '/^Package id 0:/ {gsub(/\+|°C/, "", $4); print $4; found=1} END {if (!found) {while (("LANG=C sensors" | getline l) > 0) if (l ~ /^Tctl:/) {match(l, /\+([0-9.]+)/, a); print a[1]; break}}}'`,
                     "bar-cpu-circprog",
                     "bar-cpu-txt",
                     "bar-cpu-icon"


### PR DESCRIPTION
### Summary

This PR updates the CPU temperature command to dynamically support both Intel and AMD processors. It improves hardware compatibility across systems by detecting the appropriate sensor label at runtime.

### Changes
- Updated `sensors` command to use a dynamic `awk` one-liner.
- Handles:
  - `Package id 0:` for Intel CPUs.
  - `Tctl:` for AMD CPUs.

### Testing
- ✅ Tested on Intel system with `Package id 0` sensor.
- ✅ Tested on AMD system with `Tctl` sensor.
- ✅ Verified temperature values are parsed correctly in both cases.

This ensures consistent behavior regardless of CPU vendor.
