### PR TITLE
Update statusicons.js

### DIFF
--- a/src/share/sleex/modules/.commonwidgets/statusicons.js
+++ b/src/share/sleex/modules/.commonwidgets/statusicons.js
@@ -32,9 +32,18 @@ export const MicMuteIndicator = () => Widget.Revealer({
     setup: (self) => self.hook(Audio, (self) => {
         self.revealChild = Audio.microphone?.stream?.isMuted;
     }),
-    child: MaterialIcon('mic_off', 'norm'),
+    child: Widget.Button({
+        onClicked: () => {
+            // Only mute if not already muted
+            if (!Audio.microphone?.stream?.isMuted) {
+                Audio.microphone?.stream?.mute();
+            }
+            // Do nothing if already muted
+        },
+        child: MaterialIcon('mic_off', 'norm'),
+        tooltip: 'Mute microphone',
+    }),
 });
-
 
 export const NotificationIndicator = (notifCenterName = 'dashboard') => {
     const widget = Widget.Revealer({


### PR DESCRIPTION
PLEASE TEST BEFORE YOU MERGE

- Making the MicMuteIndicator Only Mute (Not Unmute) on Click To modify your Hyprland menubar widget so that clicking the microphone icon only mutes (but never unmutes or restores the previous state/icon), you need to Ensure the click handler only triggers the mute action if the microphone is not already muted.
- Update the Stack Widget Correctly. Inside the hook, always update the stack.shown property, not widgetContent.shown. This ensures the correct child is displayed.
- Ensure Language List is Complete. Make sure your languages array includes all layouts you use (e.g., both "us" and "gr"), with the correct layout and name fields.
- Use the Correct Layout Name. Sometimes Hyprland may emit a layout name like "us" or "gr", but your matching logic expects something else. Always log or inspect the value of layoutName in the hook to ensure your matching is correct.