### PR TITLE
Fixes the overflow of weather text in dashboard widget

### DIFF
--- a/src/share/sleex/modules/dashboard/HomeWidgetGroup.qml
+++ b/src/share/sleex/modules/dashboard/HomeWidgetGroup.qml
@@ -168,7 +168,10 @@ Rectangle {
                 Layout.fillHeight: true
 
                 Column {
-                    anchors.centerIn: parent
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.margins: 20
                     spacing: 10
                     
                     Text {
@@ -180,11 +183,14 @@ Rectangle {
                     }
 
                     Text {
-                        //text: Weather.condition
                         text: Weather.condition || qsTr("Loading...")
-                        font.pixelSize: 30
+                        font.pixelSize: 20
                         color: Appearance.colors.colOnLayer1
-                        anchors.horizontalCenter: parent.horizontalCenter
+                        width: parent.width
+                        wrapMode: Text.WordWrap
+                        horizontalAlignment: Text.AlignHCenter
+                        maximumLineCount: 2
+                        elide: Text.ElideRight
                     }
                 }
 


### PR DESCRIPTION
## This PR fixes the weather text overflow in dashboard

### Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/56648ba6-5680-4963-b10c-760280bb68a5" />

### After:
<img width="1920" height="1080" alt="image2" src="https://github.com/user-attachments/assets/d49d86c5-8576-4409-af5a-7258a4bf9279" />
