### PR TITLE
chore: Fix qml service startup crashes, add battery config, and behavior settings

### DIFF
--- a/src/share/sleex/modules/common/Config.qml
+++ b/src/share/sleex/modules/common/Config.qml
@@ -3,12 +3,15 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import Quickshell
 import Quickshell.Io
-
 Singleton {
     id: root
+    signal loaded()
     property string filePath: Directories.shellConfigPath
     property alias options: configOptionsJsonAdapter
 
+    // NOTE: The manual save() function was removed. The original design of using
+    // onAdapterUpdated is more reliable. The key is to correctly mark the
+    // adapter as "dirty" from the UI, which is handled in BehaviorConfig.qml.
     function setNestedValue(nestedKey, value) {
         let keys = nestedKey.split(".");
         let obj = root.options;
@@ -44,7 +47,14 @@ Singleton {
 
         watchChanges: true
         onFileChanged: reload()
+        // NOTE: Restored to original behavior. This automatically saves the file
+        // whenever the adapter detects a change.
         onAdapterUpdated: writeAdapter()
+        onLoadedChanged: {
+            if (loaded) {
+                root.loaded()
+            }
+        }
         onLoadFailed: error => {
             if (error == FileViewError.FileNotFound) {
                 writeAdapter();
@@ -91,6 +101,7 @@ Singleton {
                 property int low: 20
                 property int critical: 5
                 property int suspend: 2
+                property bool sound: true
             }
 
             property JsonObject bar: JsonObject {

--- a/src/share/sleex/modules/common/Config.qml
+++ b/src/share/sleex/modules/common/Config.qml
@@ -91,7 +91,7 @@ Singleton {
                 property int low: 20
                 property int critical: 5
                 property int suspend: 2
-                property bool sound: true
+                property bool sound: true //Added for Battery Sound Toggle
             }
 
             property JsonObject bar: JsonObject {

--- a/src/share/sleex/modules/common/Config.qml
+++ b/src/share/sleex/modules/common/Config.qml
@@ -3,15 +3,12 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import Quickshell
 import Quickshell.Io
+
 Singleton {
     id: root
-    signal loaded()
     property string filePath: Directories.shellConfigPath
     property alias options: configOptionsJsonAdapter
 
-    // NOTE: The manual save() function was removed. The original design of using
-    // onAdapterUpdated is more reliable. The key is to correctly mark the
-    // adapter as "dirty" from the UI, which is handled in BehaviorConfig.qml.
     function setNestedValue(nestedKey, value) {
         let keys = nestedKey.split(".");
         let obj = root.options;
@@ -47,14 +44,7 @@ Singleton {
 
         watchChanges: true
         onFileChanged: reload()
-        // NOTE: Restored to original behavior. This automatically saves the file
-        // whenever the adapter detects a change.
         onAdapterUpdated: writeAdapter()
-        onLoadedChanged: {
-            if (loaded) {
-                root.loaded()
-            }
-        }
         onLoadFailed: error => {
             if (error == FileViewError.FileNotFound) {
                 writeAdapter();

--- a/src/share/sleex/modules/settings/BehaviorConfig.qml
+++ b/src/share/sleex/modules/settings/BehaviorConfig.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts
 import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
+import Quickshell.Hyprland // Ensure Hyprland is imported
 
 ContentPage {
     forceWidth: true
@@ -112,7 +113,10 @@ ContentPage {
             text: "Earbang protection"
             checked: Config.options.audio.protection.enable
             onCheckedChanged: {
-                Config.options.audio.protection.enable = checked;
+                // Clone and replace to trigger automatic save
+                let newOptions = Object.assign({}, Config.options);
+                newOptions.audio.protection.enable = checked;
+                Config.options = newOptions;
             }
             StyledToolTip {
                 content: "Prevents abrupt increments and restricts volume limit"
@@ -151,12 +155,14 @@ ContentPage {
     ContentSection {
         title: "Battery"
 
-        //Added Toggle for battery notification sounds
         ConfigSwitch {
             text: "Enable battery notification sounds"
-            checked: Config.options.battery.sound !== false
+            checked: Config.options.battery.sound
             onCheckedChanged: {
-                Config.options.battery.sound = checked;
+                // Clone and replace to trigger automatic save
+                let newOptions = Object.assign({}, Config.options);
+                newOptions.battery.sound = checked;
+                Config.options = newOptions;
             }
         }
         ConfigRow {

--- a/src/share/sleex/modules/settings/BehaviorConfig.qml
+++ b/src/share/sleex/modules/settings/BehaviorConfig.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
-import Quickshell.Hyprland // Ensure Hyprland is imported
 
 ContentPage {
     forceWidth: true
@@ -105,38 +104,143 @@ ContentPage {
 
         }
     }
-
-
-    ContentSection {
-        title: "Audio"
-        ConfigSwitch {
-            text: "Earbang protection"
-            checked: Config.options.audio.protection.enable
-            onCheckedChanged: {
-                // Clone and replace to trigger automatic save
-                let newOptions = Object.assign({}, Config.options);
-                newOptions.audio.protection.enable = checked;
-                Config.options = newOptions;
+    
+        ContentSection {
+            title: "Audio"
+            
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: 4
+                Layout.bottomMargin: 8
+    
+                Rectangle {
+                    Layout.fillWidth: true
+                    height: childrenRect.height + 25
+                    color: "#40FF9800"
+                    radius: 6
+    
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.margins: 10
+    
+                        Label {
+                            text: "🐞"
+                            font.pixelSize: 16 // Slightly smaller icon
+                            Layout.alignment: Qt.AlignVCenter
+                            rightPadding: 6
+                        }
+    
+                        Label {
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignVCenter
+                            text: "<b>TOGGLE BUG:</b> Manual edit required in <code>~/.sleex/settings.json</code>"
+                            font.pixelSize: 12
+                            wrapMode: Text.WordWrap
+                            textFormat: Text.RichText
+                            color: "white"
+                        }
+                    }
+                }
             }
-            StyledToolTip {
-                content: "Prevents abrupt increments and restricts volume limit"
+    
+            ConfigSwitch {
+                text: "Earbang protection"
+                checked: Config.options.audio.protection.enable
+                onCheckedChanged: {
+                    Config.options.audio.protection.enable = checked;
+                }
+                StyledToolTip {
+                    content: "Prevents abrupt increments and restricts volume limit"
+                }
+            }
+            ConfigSpinBox {
+                text: "Earbang limit"
+                value: Config.options.audio.protection.maxAllowed
+                from: 0
+                to: 100
+                stepSize: 1
+                onValueChanged: {
+                    Config.options.audio.protection.maxAllowed = value;
+                }
+                StyledToolTip {
+                    content: "Maximum volume level allowed by earbang protection"
+                }
             }
         }
-
-        ConfigSpinBox {
-            text: "Earbang limit"
-            value: Config.options.audio.protection.maxAllowed
-            from: 0
-            to: 100
-            stepSize: 1
-            onValueChanged: {
-                Config.options.audio.protection.maxAllowed = value;
+    
+        ContentSection {
+            title: "Battery"
+    
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.topMargin: 4
+                Layout.bottomMargin: 8
+    
+                Rectangle {
+                    Layout.fillWidth: true
+                    height: childrenRect.height + 25
+                    color: "#40FF9800"
+                    radius: 6
+    
+                    RowLayout {
+                        anchors.fill: parent
+                        anchors.margins: 10
+    
+                        Label {
+                            text: "🐞"
+                            font.pixelSize: 14
+                            Layout.alignment: Qt.AlignVCenter
+                            rightPadding: 6
+                        }
+    
+                        Label {
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignVCenter
+                            text: "<b>TOGGLE BUG:</b> Manual edit required in <code>~/.sleex/settings.json</code>"
+                            font.pixelSize: 12
+                            wrapMode: Text.WordWrap
+                            textFormat: Text.RichText
+                            color: "white"
+                        }
+                    }
+                }
             }
-            StyledToolTip {
-                content: "Maximum volume level allowed by earbang protection"
+    
+            ConfigSwitch {
+                text: "Enable battery notification sounds"
+                checked: Config.options.battery.sound
+                onCheckedChanged: {
+                    // Clone and replace to trigger automatic save
+                    let newOptions = Object.assign({}, Config.options);
+                    newOptions.battery.sound = checked;
+                    Config.options = newOptions;
+                }
+            }
+            ConfigRow {
+                uniform: true
+                ConfigSpinBox {
+                    text: "Low warning"
+                    value: Config.options.battery.low
+                    from: 0
+                    to: 100
+                    stepSize: 5
+                    onValueChanged: {
+                        Config.options.battery.low = value;
+                    }
+                }
+                ConfigSpinBox {
+                    text: "Critical warning"
+                    value: Config.options.battery.critical
+                    from: 0
+                    to: 100
+                    stepSize: 5
+                    onValueChanged: {
+                        Config.options.battery.critical = value;
+                    }
+                }
             }
         }
-    }
+    
 
     ContentSection {
         title: "AI"
@@ -148,44 +252,6 @@ ContentPage {
             wrapMode: TextEdit.Wrap
             onTextChanged: {
                 Config.options.ai.systemPrompt = text;
-            }
-        }
-    }
-
-    ContentSection {
-        title: "Battery"
-
-        ConfigSwitch {
-            text: "Enable battery notification sounds"
-            checked: Config.options.battery.sound
-            onCheckedChanged: {
-                // Clone and replace to trigger automatic save
-                let newOptions = Object.assign({}, Config.options);
-                newOptions.battery.sound = checked;
-                Config.options = newOptions;
-            }
-        }
-        ConfigRow {
-            uniform: true
-            ConfigSpinBox {
-                text: "Low warning"
-                value: Config.options.battery.low
-                from: 0
-                to: 100
-                stepSize: 5
-                onValueChanged: {
-                    Config.options.battery.low = value;
-                }
-            }
-            ConfigSpinBox {
-                text: "Critical warning"
-                value: Config.options.battery.critical
-                from: 0
-                to: 100
-                stepSize: 5
-                onValueChanged: {
-                    Config.options.battery.critical = value;
-                }
             }
         }
     }

--- a/src/share/sleex/services/Audio.qml
+++ b/src/share/sleex/services/Audio.qml
@@ -3,6 +3,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Services.Pipewire
 import Quickshell.Hyprland
+
 pragma Singleton
 pragma ComponentBehavior: Bound
 
@@ -17,13 +18,6 @@ Singleton {
     property PwNode source: Pipewire.defaultAudioSource
 
     signal sinkProtectionTriggered(string reason);
-
-    // New function to play event sounds.
-    function playSound(relativeSoundPath) {
-        const fullPath = "/usr/share/sleex/" + relativeSoundPath;
-        const command = `exec paplay ${fullPath}`;
-        Hyprland.dispatch(command);
-    }
 
     PwObjectTracker {
         objects: [sink, source]
@@ -53,6 +47,13 @@ Singleton {
             }
             lastVolume = sink.audio.volume;
         }
+    }
 
+    // Reverted to Hyprland.dispatch, which is the idiomatic method for this shell.
+    function playSound(relativeSoundPath) {
+        const fullPath = "/usr/share/sleex/" + relativeSoundPath;
+        // Use the absolute path to paplay to be safe.
+        const command = `exec /usr/bin/paplay ${fullPath}`;
+        Hyprland.dispatch(command);
     }
 }

--- a/src/share/sleex/services/Audio.qml
+++ b/src/share/sleex/services/Audio.qml
@@ -18,6 +18,13 @@ Singleton {
 
     signal sinkProtectionTriggered(string reason);
 
+    // New function to play event sounds.
+    function playSound(relativeSoundPath) {
+        const fullPath = "/usr/share/sleex/" + relativeSoundPath;
+        const command = `exec paplay ${fullPath}`;
+        Hyprland.dispatch(command);
+    }
+
     PwObjectTracker {
         objects: [sink, source]
     }
@@ -47,11 +54,5 @@ Singleton {
             lastVolume = sink.audio.volume;
         }
 
-        // New function to play event sounds.
-        function playSound(relativeSoundPath) {
-            const fullPath = "/usr/share/sleex/" + relativeSoundPath;
-            const command = `exec paplay ${fullPath}`;
-            Hyprland.dispatch(command);
-        }
     }
 }


### PR DESCRIPTION
**Config.qml**
Add battery-power sound property (toggle button - bug)
Adds the missing 'sound' property to the battery configuration to support the UI toggle.

**BehaviorConfig.qml**
Re-arranged Settings and added bug toggle warning
<img width="578" height="395" alt="image" src="https://github.com/user-attachments/assets/609fb636-b16b-4545-9d94-966f623e1060" />


**Audio.qml**
fix(audio): Prevent startup crash and harden sound command

**Battery.qml**
fix(battery): Prevent startup crash from race condition