### PR TITLE
Update BluetoothIndicator.qml : Prevent decimal points in battery percentage

### DIFF
--- a/src/share/sleex/modules/bar/BluetoothIndicator.qml
+++ b/src/share/sleex/modules/bar/BluetoothIndicator.qml
@@ -53,7 +53,8 @@ Item {
         // }
 
         StyledText {
-            text: `${device?.battery * 100 ?? 0}%`
+            // Round the battery percentage to avoid decimal points
+            text: `${Math.round(device?.battery * 100 ?? 0)}%`
             visible: device?.batteryAvailable ?? false
         }
 


### PR DESCRIPTION
Rounds the battery percentage for connected Bluetooth devices to prevent the UI from displaying a long string of decimal points. e.g 54.00000000001% > 54%