### PR TITLE
Added toggle split feature

### DIFF
--- a/sleex-user-config/src/.config/hypr/hyprland/keybinds_fr.conf
+++ b/sleex-user-config/src/.config/hypr/hyprland/keybinds_fr.conf
@@ -92,6 +92,10 @@ bind = Super, F, fullscreen,
 bindm = Super, mouse:272, movewindow
 bindm = Super, mouse:273, resizewindow
 
+# Toggle focused window split
+$d=[$wm]
+bindd = SUPER, J, $d toggle split, togglesplit
+
 #!
 ##! Workspace navigation
 # Switching

--- a/sleex-user-config/src/.config/hypr/hyprland/keybinds_us.conf
+++ b/sleex-user-config/src/.config/hypr/hyprland/keybinds_us.conf
@@ -92,6 +92,10 @@ bind = Super, F, fullscreen,
 bindm = Super, mouse:272, movewindow
 bindm = Super, mouse:273, resizewindow
 
+# Toggle focused window split
+$d=[$wm]
+bindd = SUPER, J, $d toggle split, togglesplit
+
 #!
 ##! Workspace navigation
 # Switching


### PR DESCRIPTION
## Summary
Add a keybinding to toggle split orientation (left → top → right → bottom).

## Why
A feature I became accustomed to while using [**HyDE**](https://github.com/HyDE-Project/HyDE), and it greatly improves workflow efficiency when managing tiled windows.

## How
- Updated keybinding configs:

  - `keybinds_fr.conf`
  - `keybinds_us.conf`

## Testing
- Verified the keybinding cycles through split orientations correctly in both FR and US layouts.

## Demo


https://github.com/user-attachments/assets/7c34b1a5-01e7-424e-b72f-d86d9f14e4d4

