### PR TITLE
Custom Weather Locations

### DIFF
--- a/src/share/sleex/modules/common/Config.qml
+++ b/src/share/sleex/modules/common/Config.qml
@@ -132,6 +132,7 @@ Singleton {
                 property string avatarPath: "file:///usr/share/sleex/assets/logo/1024px/white.png"
                 property string userDesc: "Today is a good day to have a good day!"
                 property bool enableWeather: false
+                property string weatherLocation: "" // :)
             }
 
             property JsonObject dock: JsonObject {

--- a/src/share/sleex/modules/settings/Privacy.qml
+++ b/src/share/sleex/modules/settings/Privacy.qml
@@ -8,42 +8,55 @@ import qs.modules.common.widgets
 ContentPage {
     forceWidth: true
 
-    ContentSection {
-        title: "Policies"
-        ContentSubsectionLabel {
-            text: "AI"
-        }
-        ConfigSelectionArray {
-            currentValue: Config.options.policies.ai
-            onSelected: newValue => {
-                Config.options.policies.ai = newValue;
+        ContentSection {
+            title: "Policies"
+            ContentSubsectionLabel {
+                text: "AI"
             }
-            options: [
-                {
-                    displayName: "No",
-                    value: 0
-                },
-                {
-                    displayName: "Yes",
-                    value: 1
-                },
-                {
-                    displayName: "Local only",
-                    value: 2
+            ConfigSelectionArray {
+                currentValue: Config.options.policies.ai
+                onSelected: newValue => {
+                    Config.options.policies.ai = newValue;
                 }
-            ]
-        }
+                options: [
+                    {
+                        displayName: "No",
+                        value: 0
+                    },
+                    {
+                        displayName: "Yes",
+                        value: 1
+                    },
+                    {
+                        displayName: "Local only",
+                        value: 2
+                    }
+                ]
+            }
 
-        ContentSubsectionLabel {
-            text: "Weather"
+            ContentSubsectionLabel {
+                text: "Weather"
+            }
+            ConfigSwitch {
+                id: weatherSwitch
+                text: "Enabled"
+                checked: Config.options.dashboard.enableWeather
+                onClicked: checked = !checked;
+                onCheckedChanged: Config.options.dashboard.enableWeather = checked
+                StyledToolTip { content: "The weather module uses your approximate location based on your local IP. It uses the https://wttr.in provider." }
+            }
+
+            MaterialTextField {
+                id: weatherLocation
+                Layout.fillWidth: true
+                placeholderText: "Weather Location"
+                text: Config.options.dashboard.weatherLocation
+                wrapMode: TextEdit.Wrap
+
+                onEditingFinished: {
+                    // Only replace spaces with dashes when the user is done typing
+                    Config.options.dashboard.weatherLocation = text.replace(/ /g, "-");
+                }
+            }
         }
-        ConfigSwitch {
-            id: weatherSwitch
-            text: "Enabled"
-            checked: Config.options.dashboard.enableWeather
-            onClicked: checked = !checked;
-            onCheckedChanged: Config.options.dashboard.enableWeather = checked
-            StyledToolTip { content: "The weather module uses your approximate location based on your local IP. It uses the https://wttr.in provider." }
-        }
-    }
 }


### PR DESCRIPTION
## Summary

By default, the weather widget displays the weather of the closest city based on your IP address.  
This PR includes modifications to allow users to specify a custom location instead.

## Changes
- **Modified `Weather.qml`**
- **Modified `Config.qml`**
- **Modified `Privacy.qml`:**
##
- Added an option **Settings > Privacy > Weather Location**  
- If a valid location is found, the widget will display the weather for that location.  
- If the text field is blank or has an unknown area, fallback to the default method - closest city to your IP address.  
##

## Demo


https://github.com/user-attachments/assets/91e0f007-cf3d-401f-bb77-413e0cc30a5e


