### PR TITLE
Insomnia mode

### DIFF
--- a/sleex-user-config/src/.config/hypr/custom/scripts/Insomnia.sh
+++ b/sleex-user-config/src/.config/hypr/custom/scripts/Insomnia.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Get all connected monitors and check if any external monitor is connected
+connected_monitors=$(hyprctl monitors -j)
+external_monitor_connected=$(echo "$connected_monitors" | jq -r '.[] | select(.name != "eDP-1") | .name' | head -n1)
+
+if [ -n "$external_monitor_connected" ]; then
+    # External monitor is connected - toggle eDP-1 display
+    is_enabled=$(echo "$connected_monitors" | jq -r '.[] | select(.name == "eDP-1") | .disabled')
+
+    if [ "$is_enabled" = "false" ]; then
+        # If display is enabled, disable it
+        hyprctl keyword monitor "eDP-1,disable"
+        brightnessctl -sd asus::kbd_backlight set 0
+        python /usr/share/sleex/scripts/wayland-idle-inhibitor.py
+    else
+        # If display is disabled, enable it
+        hyprctl keyword monitor "eDP-1,preferred,auto,1"
+        brightnessctl -rd asus::kbd_backlight
+        pkill wayland-idle
+    fi
+else
+    # No external monitor detected - toggle DPMS instead
+    dpms_status=$(echo "$connected_monitors" | jq -r '.[] | select(.name == "eDP-1") | .dpmsStatus')
+
+    if [ "$dpms_status" = "true" ]; then
+        # If DPMS is on, turn it off (wake display)
+        hyprctl dispatch dpms off eDP-1
+        brightnessctl -sd asus::kbd_backlight set 0
+        python /usr/share/sleex/scripts/wayland-idle-inhibitor.py
+    else
+        # If DPMS is off, turn it on (sleep display)
+        hyprctl dispatch dpms on eDP-1
+        brightnessctl -rd asus::kbd_backlight
+        pkill wayland-idle
+    fi
+fi

--- a/sleex-user-config/src/.config/hypr/hyprland/keybinds_fr.conf
+++ b/sleex-user-config/src/.config/hypr/hyprland/keybinds_fr.conf
@@ -73,6 +73,7 @@ bind = Super+Shift+Alt, R, exec, /usr/share/sleex/scripts/record-script.sh --ful
 ##! Session
 # bind = Super, L, exec, hyprlock # Lock session
 bind = Super, L, global, quickshell:lockScreen # Lock session
+bind = Super, M, exec, ~/.config/hypr/custom/scripts/Insomnia.sh # Toggle Insomnia Mode
 
 #!
 ##! Window management

--- a/sleex-user-config/src/.config/hypr/hyprland/keybinds_us.conf
+++ b/sleex-user-config/src/.config/hypr/hyprland/keybinds_us.conf
@@ -73,6 +73,7 @@ bind = Super+Shift+Alt, R, exec, /usr/share/sleex/scripts/record-script.sh --ful
 ##! Session
 # bind = Super, L, exec, hyprlock # Lock session
 bind = Super, L, global, quickshell:lockScreen # Lock session
+bind = Super, M, exec, ~/.config/hypr/custom/scripts/Insomnia.sh # Toggle Insomnia Mode
 
 #!
 ##! Window management


### PR DESCRIPTION
## Summary

While Caffeine mode prevents the system from going to sleep by keeping the display awake, Insomnia mode allows the display to turn off while the system itself remains awake, perfect for background tasks such as downloading large files overnight. 

__NOTE:__ The advantages of this feature are more significant for laptop users, while desktop users may experience fewer direct benefits. Desktop users can just turn off their monitor. Laptop users however need to mess around many settings. This changes that.

## Changes

Added `Insomnia.sh` script that:

- Detects connected monitors via `hyprctl`
- Toggles the built-in display (eDP-1) when an external monitor is present (if you wanna use the monitor exclusively)
- Manages keyboard backlight with `brightnessctl` ( I have an ASUS laptop)
- Starts/stops an idle inhibitor to keep the system awake without requiring the screen to stay on
- Falls back to DPMS toggling when no external monitor is connected

## Motivation

Think of it like this:

- **Caffeine mode**: You drink coffee, your eyes stay open, and you don't fall asleep. Similarly, the computer never sleeps because the screen stays on.
- **Insomnia mode**: Your eyes are closed, yet you still can't fall asleep. The computer's display turns off, but the system stays awake in the background.

This makes Insomnia mode especially useful when you want to:

- Download or seed large files without interruption
- Keep services running (servers, containers, background jobs) without a glowing display
- Save power and screen lifetime while ensuring the system never suspends

## Notes

- **Dependencies**: `hyprctl`, `jq`, `brightnessctl`, Python
- **Default assumptions**: Internal display is `eDP-1` and backlight device is `asus::kbd_backlight`
- Adaptable to other hardware by tweaking device names in the script
- BTW this is most useful when using a laptop and external monitor configuration

## Demo

- This is me toggling on/off as a demonstration

https://github.com/user-attachments/assets/00f946a3-13c1-421a-aef4-2b53d43a1987

## Keybind (Super+M)

<img width="847" height="700" alt="image" src="https://github.com/user-attachments/assets/41ebb3ef-9f0f-4df4-8b84-4d3a69acf571" />
