### PR TITLE
Custom dns

### DIFF
--- a/sleex-user-config/src/.config/hypr/hyprland/keybinds_fr.conf
+++ b/sleex-user-config/src/.config/hypr/hyprland/keybinds_fr.conf
@@ -73,6 +73,7 @@ bind = Super+Shift+Alt, R, exec, /usr/share/sleex/scripts/record-script.sh --ful
 ##! Session
 # bind = Super, L, exec, hyprlock # Lock session
 bind = Super, L, global, quickshell:lockScreen # Lock session
+bind = Super, M, exec, ~/.config/hypr/custom/scripts/Insomnia.sh # Toggle Insomnia Mode
 
 #!
 ##! Window management

--- a/src/share/sleex/modules/common/Config.qml
+++ b/src/share/sleex/modules/common/Config.qml
@@ -133,6 +133,7 @@ Singleton {
                 property string userDesc: "Today is a good day to have a good day!"
                 property bool enableWeather: false
                 property string weatherLocation: "" // :)
+                property string customDNS: "" // :)
             }
 
             property JsonObject dock: JsonObject {

--- a/src/share/sleex/modules/common/Config.qml
+++ b/src/share/sleex/modules/common/Config.qml
@@ -132,8 +132,8 @@ Singleton {
                 property string avatarPath: "file:///usr/share/sleex/assets/logo/1024px/white.png"
                 property string userDesc: "Today is a good day to have a good day!"
                 property bool enableWeather: false
-                property string weatherLocation: "" // :)
-                property string customDNS: "" // :)
+                property string weatherLocation: ""
+                property string customDNS: ""
             }
 
             property JsonObject dock: JsonObject {

--- a/src/share/sleex/modules/settings/Privacy.qml
+++ b/src/share/sleex/modules/settings/Privacy.qml
@@ -10,40 +10,36 @@ ContentPage {
 
         ContentSection {
             title: "Policies"
+
             ContentSubsectionLabel {
                 text: "AI"
             }
+
             ConfigSelectionArray {
                 currentValue: Config.options.policies.ai
                 onSelected: newValue => {
                     Config.options.policies.ai = newValue;
                 }
                 options: [
-                    {
-                        displayName: "No",
-                        value: 0
-                    },
-                    {
-                        displayName: "Yes",
-                        value: 1
-                    },
-                    {
-                        displayName: "Local only",
-                        value: 2
-                    }
+                    { displayName: "No", value: 0 },
+                    { displayName: "Yes", value: 1 },
+                    { displayName: "Local only", value: 2 }
                 ]
             }
+        }
 
-            ContentSubsectionLabel {
-                text: "Weather"
-            }
+        ContentSection {
+            title: "Weather"
+
             ConfigSwitch {
                 id: weatherSwitch
                 text: "Enabled"
                 checked: Config.options.dashboard.enableWeather
-                onClicked: checked = !checked;
                 onCheckedChanged: Config.options.dashboard.enableWeather = checked
-                StyledToolTip { content: "The weather module uses your approximate location based on your local IP. It uses the https://wttr.in provider." }
+
+                StyledToolTip {
+                    content: "The weather module uses your approximate location based on your local IP. It uses the https://wttr.in provider."
+                }
             }
 
             MaterialTextField {
@@ -58,5 +54,28 @@ ContentPage {
                     Config.options.dashboard.weatherLocation = text.replace(/ /g, "-");
                 }
             }
+        }
+
+        ContentSection {
+            title: "DNS"
+
+
+            MaterialTextField {
+                id: customDNS
+                Layout.fillWidth: true
+                placeholderText: "DNS Server"
+                text: Config.options.dashboard.customDNS
+                wrapMode: TextEdit.Wrap
+
+                onEditingFinished: {
+                    // Save the value
+                    Config.options.dashboard.customDNS = text
+
+                    // Run the Python script
+                    Quickshell.execDetached(["python", "/usr/share/sleex/scripts/set-dns.py"])
+
+                }
+            }
+
         }
 }

--- a/src/share/sleex/modules/settings/Privacy.qml
+++ b/src/share/sleex/modules/settings/Privacy.qml
@@ -35,6 +35,7 @@ ContentPage {
                 id: weatherSwitch
                 text: "Enabled"
                 checked: Config.options.dashboard.enableWeather
+                onClicked: checked = !checked;
                 onCheckedChanged: Config.options.dashboard.enableWeather = checked
 
                 StyledToolTip {

--- a/src/share/sleex/scripts/set-dns.py
+++ b/src/share/sleex/scripts/set-dns.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import subprocess
+import json
+import os
+import getpass
+
+# Path to the settings JSON
+CONFIG_FILE = os.path.expanduser("~/.sleex/settings.json")
+
+def run_cmd(cmd, capture_output=True):
+    """Run a shell command and return its output."""
+    result = subprocess.run(cmd, shell=True, text=True,
+                            capture_output=capture_output)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+def get_custom_dns():
+    """Read customDNS from settings.json."""
+    if not os.path.exists(CONFIG_FILE):
+        print(f"Settings file not found: {CONFIG_FILE}")
+        return None
+    try:
+        with open(CONFIG_FILE, "r") as f:
+            config = json.load(f)
+        # Navigate to dashboard.customDNS
+        dns = config.get("dashboard", {}).get("customDNS", "").strip()
+        if dns:
+            return dns
+        else:
+            print("customDNS is empty in settings.json")
+            return None
+    except Exception as e:
+        print(f"Failed to read settings.json: {e}")
+        return None
+
+def main():
+    dns_server = get_custom_dns()
+    if not dns_server:
+        print("Please set a custom DNS in ~/.sleex/settings.json under dashboard.customDNS")
+        return
+
+    # Detect the active connection
+    active_conn_cmd = "nmcli -t -f NAME,DEVICE connection show --active | head -n1 | cut -d: -f1"
+    active_conn = run_cmd(active_conn_cmd)
+    if not active_conn:
+        print("No active network connection found.")
+        return
+
+    print(f"Setting DNS {dns_server} for connection '{active_conn}'...")
+
+    # Check connection type
+    con_type_cmd = f"nmcli -g connection.type connection show '{active_conn}'"
+    con_type = run_cmd(con_type_cmd)
+
+    # If Wi-Fi, check for PSK
+    if con_type == "wifi":
+        psk_cmd = f"nmcli -g 802-11-wireless-security.psk connection show '{active_conn}'"
+        psk = run_cmd(psk_cmd)
+        if not psk:
+            psk = getpass.getpass("Wi-Fi password not found. Please enter it: ")
+            subprocess.run(f"nmcli connection modify '{active_conn}' wifi-sec.psk '{psk}'", shell=True)
+
+    # Set the DNS and ignore auto DNS
+    set_dns_cmd = f"nmcli connection modify '{active_conn}' ipv4.dns '{dns_server}' ipv4.ignore-auto-dns yes"
+    if run_cmd(set_dns_cmd) is None:
+        print(f"Failed to set DNS {dns_server} for connection '{active_conn}'.")
+        return
+
+    # Reactivate the connection
+    subprocess.run(f"nmcli connection down '{active_conn}'", shell=True)
+    subprocess.run(f"nmcli connection up '{active_conn}'", shell=True)
+
+    print("DNS updated successfully.")
+    subprocess.run("nmcli dev show | grep DNS", shell=True)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Added an easier way to change DNS on the fly

__NOTE:__ Idk why `set-dns.py` is not running after:
<img width="885" height="271" alt="image" src="https://github.com/user-attachments/assets/27f4f7e7-b26a-421f-b614-92d41285ffb4" />

## Before

<img width="900" height="650" alt="Screenshot_2025-09-17_10 08 52" src="https://github.com/user-attachments/assets/8f062674-fcc6-4718-9890-966e7319ae23" />


## After

<img width="900" height="650" alt="image" src="https://github.com/user-attachments/assets/ce0acd1e-9ec5-4dd1-ac2a-6510d0eb4ff9" />


## Changes

Added `set-dns.py` script that:

- Reads dashboard.customDNS from the user settings.
- Detects the active network connection using nmcli.
- Prompts for Wi-Fi password if missing, ensuring the connection can be updated.
- Sets the custom DNS and disables automatic DNS resolution.
- Reactivates the connection to apply changes immediately.
- Prints the updated DNS configuration for verification.

## Notes

- I tried adding a button to apply the settings by executing the script. It did not work. Idk why.
- I also tried adding a switch to toggle the script when switched on. also didnt work.


## Usage

1. Open Settings > Privacy
2. Enter the DNS Address
3. Run: `python /usr/share/sleex/scripts/set-dns.py`

## Demo

- This is me changing the DNS as a demonstration


https://github.com/user-attachments/assets/3b5378e1-5783-415d-99ec-7dcb9ea97020



