### PR TITLE
Fixed GitHub Author Link

### DIFF
--- a/src/share/sleex/modules/dashboard/HomeWidgetGroup.qml
+++ b/src/share/sleex/modules/dashboard/HomeWidgetGroup.qml
@@ -134,16 +134,27 @@ Rectangle {
                         anchors.horizontalCenter: parent.horizontalCenter
                     }
 
-                    GhCalendar {}
+                   GhCalendar {}
+
                     
                     Text {
                         text: `@${Github.author}`
                         color: Appearance.colors.colOnLayer1
                         font.pixelSize: 16
                         anchors.horizontalCenter: parent.horizontalCenter
+
+                        MouseArea {
+                            id: githubLink
+                            anchors.fill: parent
+                            cursorShape: Qt.PointingHandCursor
+
+                            onClicked: {
+                                // Open GitHub URL in the default web browser
+                                Qt.openUrlExternally(`https://github.com/${Github.author}`)
+                            }
+                        }
                     }
                 }
-                
             }
         }
         


### PR DESCRIPTION
## Summary
Add GitHub author link to GhCalendar component allowing users to click the label and open the corresponding GitHub profile in their default web browser.

## Fix

Previously, this PR accidentally removed the weather loader which is very important.
This update ONLY modifies the `GhCalendar` component WITHOUT touching anything else.

## Why
Convenience
 
## Demo

https://github.com/user-attachments/assets/458a5cce-48a9-4c92-9520-a091736fdf04





