### PR TITLE
Default Media Player

### DIFF
--- a/src/share/sleex/modules/common/Config.qml
+++ b/src/share/sleex/modules/common/Config.qml
@@ -148,6 +148,7 @@ Singleton {
                 property string userDesc: "Today is a good day to have a good day!"
                 property bool enableWeather: false
                 property string weatherLocation: ""
+                property string mediaPlayer: ""
             }
 
             property JsonObject dock: JsonObject {

--- a/src/share/sleex/modules/mediaControls/PlayerControlBlank.qml
+++ b/src/share/sleex/modules/mediaControls/PlayerControlBlank.qml
@@ -158,7 +158,26 @@ Item {
                         property real size: 44
                         implicitWidth: size
                         implicitHeight: size
-                        onClicked: {} // Do nothing
+                        onClicked: {
+
+                        if (Config.options.dashboard.mediaPlayer === "YouTube Music") {
+                            Qt.openUrlExternally("https://music.youtube.com")
+                        } else if (Config.options.dashboard.mediaPlayer === "YouTube") {
+                               Qt.openUrlExternally("https://youtube.com")
+                        } else if (Config.options.dashboard.mediaPlayer === "Spotify") {
+                               Qt.openUrlExternally("https://open.spotify.com")
+                        } else if (Config.options.dashboard.mediaPlayer === "Amazon Music") {
+                               Qt.openUrlExternally("https://music.amazon.com")
+                        } else if (Config.options.dashboard.mediaPlayer === "Apple Music") {
+                               Qt.openUrlExternally("https://music.apple.com")
+                        } else if (Config.options.dashboard.mediaPlayer === "Tidal") {
+                               Qt.openUrlExternally("https://tidal.com")
+                        } else if (Config.options.dashboard.mediaPlayer === "Sound Cloud") {
+                               Qt.openUrlExternally("https://soundcloud.com")
+                        } else if (Config.options.dashboard.mediaPlayer === "Deezer") {
+                               Qt.openUrlExternally("https://www.deezer.com")
+                          }
+                        }
 
                         buttonRadius: Appearance?.rounding.normal
                         colBackground: blendedColors.colSecondaryContainer

--- a/src/share/sleex/modules/mediaControls/PlayerControlBlank.qml
+++ b/src/share/sleex/modules/mediaControls/PlayerControlBlank.qml
@@ -159,45 +159,16 @@ Item {
                         implicitWidth: size
                         implicitHeight: size
                         onClicked: {
+                           let player = Config.options.dashboard.mediaPlayer
 
-                      if (Config.options.dashboard.mediaPlayer === "YouTube Music") {
-                               Quickshell.execDetached(["youtube-music"])
-                        } else if (Config.options.dashboard.mediaPlayer === "YouTube Music Web") {
-                               Qt.openUrlExternally("https://music.youtube.com") }
-                               
-                        if (Config.options.dashboard.mediaPlayer === "YouTube") {
-                               Quickshell.execDetached(["youtube"])
-                        } else if (Config.options.dashboard.mediaPlayer === "YouTube Web") {
-                               Qt.openUrlExternally("https://youtube.com")}
-                               
-                        if (Config.options.dashboard.mediaPlayer === "Spotify") {
-                               Quickshell.execDetached(["spotify"])
-                        } else if (Config.options.dashboard.mediaPlayer === "Spotify Web") {
-                               Qt.openUrlExternally("https://open.spotify.com")}
-                               
-                        if (Config.options.dashboard.mediaPlayer === "High Tide") {
-                               Quickshell.execDetached(["high-tide"])
-                        } else if (Config.options.dashboard.mediaPlayer === "Tidal Web") {
-                               Qt.openUrlExternally("https://tidal.com")}
-                               
-                        if (Config.options.dashboard.mediaPlayer === "Deezer") {
-                               Quickshell.execDetached(["deezer"])
-                        } else if (Config.options.dashboard.mediaPlayer === "Deezer Web") {
-                               Qt.openUrlExternally("https://www.deezer.com")}
-                               
-                        if (Config.options.dashboard.mediaPlayer === "Apple Music") {
-                               Qt.openUrlExternally("https://music.apple.com")}
-                        
-                        if (Config.options.dashboard.mediaPlayer === "Sound Cloud") {
-                              Qt.openUrlExternally("https://soundcloud.com")}
-
-                        if (Config.options.dashboard.mediaPlayer === "Amazon Music") {
-                              Qt.openUrlExternally("https://music.amazon.com")}
-                               
-                        if (Config.options.dashboard.mediaPlayer === "Amberol") {
-                               Quickshell.execDetached(["amberol"])}
-                        }
-
+                           if (player.startsWith("http://") || player.startsWith("https://")) {
+                               // Open website
+                               Qt.openUrlExternally(player)
+                       } else {
+                           // Launch app
+                           Quickshell.execDetached([player])
+                       }
+                    }
                         buttonRadius: Appearance?.rounding.normal
                         colBackground: blendedColors.colSecondaryContainer
                         colBackgroundHover: blendedColors.colSecondaryContainerHover

--- a/src/share/sleex/modules/mediaControls/PlayerControlBlank.qml
+++ b/src/share/sleex/modules/mediaControls/PlayerControlBlank.qml
@@ -190,6 +190,9 @@ Item {
                         
                         if (Config.options.dashboard.mediaPlayer === "Sound Cloud") {
                               Qt.openUrlExternally("https://soundcloud.com")}
+
+                        if (Config.options.dashboard.mediaPlayer === "Amazon Music") {
+                              Qt.openUrlExternally("https://music.amazon.com")}
                                
                         if (Config.options.dashboard.mediaPlayer === "Amberol") {
                                Quickshell.execDetached(["amberol"])}

--- a/src/share/sleex/modules/mediaControls/PlayerControlBlank.qml
+++ b/src/share/sleex/modules/mediaControls/PlayerControlBlank.qml
@@ -160,23 +160,39 @@ Item {
                         implicitHeight: size
                         onClicked: {
 
-                        if (Config.options.dashboard.mediaPlayer === "YouTube Music") {
-                            Qt.openUrlExternally("https://music.youtube.com")
-                        } else if (Config.options.dashboard.mediaPlayer === "YouTube") {
-                               Qt.openUrlExternally("https://youtube.com")
-                        } else if (Config.options.dashboard.mediaPlayer === "Spotify") {
-                               Qt.openUrlExternally("https://open.spotify.com")
-                        } else if (Config.options.dashboard.mediaPlayer === "Amazon Music") {
-                               Qt.openUrlExternally("https://music.amazon.com")
-                        } else if (Config.options.dashboard.mediaPlayer === "Apple Music") {
-                               Qt.openUrlExternally("https://music.apple.com")
-                        } else if (Config.options.dashboard.mediaPlayer === "Tidal") {
-                               Qt.openUrlExternally("https://tidal.com")
-                        } else if (Config.options.dashboard.mediaPlayer === "Sound Cloud") {
-                               Qt.openUrlExternally("https://soundcloud.com")
-                        } else if (Config.options.dashboard.mediaPlayer === "Deezer") {
-                               Qt.openUrlExternally("https://www.deezer.com")
-                          }
+                      if (Config.options.dashboard.mediaPlayer === "YouTube Music") {
+                               Quickshell.execDetached(["youtube-music"])
+                        } else if (Config.options.dashboard.mediaPlayer === "YouTube Music Web") {
+                               Qt.openUrlExternally("https://music.youtube.com") }
+                               
+                        if (Config.options.dashboard.mediaPlayer === "YouTube") {
+                               Quickshell.execDetached(["youtube"])
+                        } else if (Config.options.dashboard.mediaPlayer === "YouTube Web") {
+                               Qt.openUrlExternally("https://youtube.com")}
+                               
+                        if (Config.options.dashboard.mediaPlayer === "Spotify") {
+                               Quickshell.execDetached(["spotify"])
+                        } else if (Config.options.dashboard.mediaPlayer === "Spotify Web") {
+                               Qt.openUrlExternally("https://open.spotify.com")}
+                               
+                        if (Config.options.dashboard.mediaPlayer === "High Tide") {
+                               Quickshell.execDetached(["high-tide"])
+                        } else if (Config.options.dashboard.mediaPlayer === "Tidal Web") {
+                               Qt.openUrlExternally("https://tidal.com")}
+                               
+                        if (Config.options.dashboard.mediaPlayer === "Deezer") {
+                               Quickshell.execDetached(["deezer"])
+                        } else if (Config.options.dashboard.mediaPlayer === "Deezer Web") {
+                               Qt.openUrlExternally("https://www.deezer.com")}
+                               
+                        if (Config.options.dashboard.mediaPlayer === "Apple Music") {
+                               Qt.openUrlExternally("https://music.apple.com")}
+                        
+                        if (Config.options.dashboard.mediaPlayer === "Sound Cloud") {
+                              Qt.openUrlExternally("https://soundcloud.com")}
+                               
+                        if (Config.options.dashboard.mediaPlayer === "Amberol") {
+                               Quickshell.execDetached(["amberol"])}
                         }
 
                         buttonRadius: Appearance?.rounding.normal

--- a/src/share/sleex/modules/settings/Sound.qml
+++ b/src/share/sleex/modules/settings/Sound.qml
@@ -131,4 +131,20 @@ ContentPage {
             }
         }
     }
+
+    ContentSection {
+        title: "Default Media Player"
+        
+        MaterialTextField {
+            
+            id: mediaPlayer
+            Layout.fillWidth: true
+            placeholderText: "Default Media Player"
+            text: Config.options.dashboard.mediaPlayer
+            wrapMode: TextEdit.Wrap
+            onEditingFinished: {
+                Config.options.dashboard.mediaPlayer = text
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

By setting a **default media player**, you no longer need to manually open the desired player each time. Simply pressing the play button in the music widget will automatically launch the corresponding media player. Tested with YouTube Music, YouTube, Spotify, Deezer, Apple Music, Amazon Music, TIDAL, and SoundCloud.

---

## Changes

* Modified `Sound.qml`
* Modified `PlayerControlBlank.qml`
* Modified `Config.qml`

---

## Note

The original idea was to launch the desktop music applications, but I couldn't get it to work consistently. Quick-launching the websites directly from the shell was the next best thing.

## Demo


https://github.com/user-attachments/assets/ed13fdb4-3479-47b1-ab68-ad2d0b031d54

