### PR TITLE
Add Restart Shell Keybind

### DIFF
--- a/sleex-user-config/src/.config/hypr/hyprland/keybinds_fr.conf
+++ b/sleex-user-config/src/.config/hypr/hyprland/keybinds_fr.conf
@@ -74,6 +74,8 @@ bind = Super+Shift+Alt, R, exec, /usr/share/sleex/scripts/record-script.sh --ful
 # bind = Super, L, exec, hyprlock # Lock session
 bind = Super, L, global, quickshell:lockScreen # Lock session
 bind = Super, M, exec, ~/.config/hypr/custom/scripts/Insomnia.sh # Toggle Insomnia Mode
+bind = Super, End, exec, pkill qs && qs -p /usr/share/sleex/shell.qml # Restart Shell
+bind = Super+Ctrl, End, exec, qs -p /usr/share/sleex/shell.qml # Start Shell
 
 #!
 ##! Window management

--- a/sleex-user-config/src/.config/hypr/hyprland/keybinds_us.conf
+++ b/sleex-user-config/src/.config/hypr/hyprland/keybinds_us.conf
@@ -74,6 +74,8 @@ bind = Super+Shift+Alt, R, exec, /usr/share/sleex/scripts/record-script.sh --ful
 # bind = Super, L, exec, hyprlock # Lock session
 bind = Super, L, global, quickshell:lockScreen # Lock session
 bind = Super, M, exec, ~/.config/hypr/custom/scripts/Insomnia.sh # Toggle Insomnia Mode
+bind = Super, End, exec, pkill qs && qs -p /usr/share/sleex/shell.qml # Restart Shell
+bind = Super+Ctrl, End, exec, qs -p /usr/share/sleex/shell.qml # Start Shell
 
 #!
 ##! Window management


### PR DESCRIPTION
## Summary

Idk why but occasionally, Quickshell will randomly crash.
The only way to activate the shell afterwards is to:

1. Restart your machine.
2. Execute a command from the terminal to start quickshell. 

This PR adds two Keybinds letting you start/restart the shell on command.

## Changes

Modified `keybinds_fr.conf`
Modified `keybinds_us.conf`

## Keybind: Super + End

- Effectively the same as the option in the dashboard.
- Kills the process and restarts it.

## Keybind: Super + Ctrl + End

- In the event that the shell crashes, you may restart it using this.
- Super + End will not revive a dead shell. Only Super + Ctrl + End as you are effectively launching a new instance.