### PR TITLE
Improved Idle Behaviour

### DIFF
--- a/sleex-user-config/src/.config/hypr/hypridle.conf
+++ b/sleex-user-config/src/.config/hypr/hypridle.conf
@@ -1,10 +1,36 @@
-$lock_cmd = hyprctl dispatch global quickshell:lockScreen
-
 general {
-    lock_cmd = $lock_cmd
+    lock_cmd = pidof hyprlock || hyprlock  # avoid starting multiple hyprlock instances.
+    before_sleep_cmd = qs -p /usr/share/sleex ipc call lock lock    # lock before suspend.
+    after_sleep_cmd = hyprctl dispatch dpms on  # to avoid having to press a key twice to turn on the display.
 }
 
 listener {
-    timeout = 300 # 5mins
-    on-timeout = $lock_cmd
+    timeout = 180                             # 3min.
+    on-timeout = brightnessctl -s set 10      # set monitor backlight to minimum, avoid 0 on OLED monitor.
+    on-resume = brightnessctl -r              # monitor backlight restore.
+}
+
+# turn off keyboard backlight if present (auto-detect device)
+listener {
+    timeout = 180    # 3min.
+    on-timeout = KBD=$(ls /sys/class/leds | grep -i kbd_backlight | head -n1) && \
+                 [ -n "$KBD" ] && brightnessctl -sd "$KBD" set 0
+    on-resume  = KBD=$(ls /sys/class/leds | grep -i kbd_backlight | head -n1) && \
+                 [ -n "$KBD" ] && brightnessctl -rd "$KBD"
+}
+
+listener {
+    timeout = 200                                              # 3min, 20sec
+    on-timeout = qs -p /usr/share/sleex ipc call lock lock     # lock screen when timeout has passed
+}
+
+listener {
+    timeout = 220                                                # 3min, 40sec
+    on-timeout = hyprctl dispatch dpms off                       # screen off when timeout has passed
+    on-resume = hyprctl dispatch dpms on && brightnessctl -r     # screen on when activity is detected after timeout has fired.
+}
+
+listener {
+    timeout = 240                      # 4min
+    on-timeout = systemctl suspend     # suspend pc
 }


### PR DESCRIPTION
# Summary

**The original `hypridle.conf` shipped with _Sleex_ is functional.**
**This PR adds to that functionality by introducing some quality of life enhancements.**

# Enhancements

- After 3 minutes of idle, the **display will be dimmed** and the **keyboard back-light will turn off**.
- After 3 minutes, 20 seconds: the computer will **lock** itself.
- After 3 minutes, 40 seconds: the computer **screen will turn off** via DPMS.
- After 4 minutes, the computer will **suspend**.

# Comments

**In my opinion, the execution times are not too long while also not being too short.**
**I believe that it achieves a perfect balance as the enhancements occur gracefully.**

**However, they can always be changed depending on the user's preference.**

# Demo

#### NOTE: Adjusted the times significantly to show the the functionality in its entirety. (Sped up)

https://github.com/user-attachments/assets/ad52793e-8da8-4474-a7ee-8d930d1680af