### PR TITLE
Rename windowrulev2 to windowrule with updated syntax

### DIFF
--- a/src/etc/sleex/hyprland/colors.conf
+++ b/src/etc/sleex/hyprland/colors.conf
@@ -29,4 +29,4 @@ plugin {
     }
 }
 
-windowrulev2 = bordercolor rgba(93cdf6AA) rgba(93cdf677),pinned:1
+windowrule = border_color rgba(93cdf6AA) rgba(93cdf677), match:pin true


### PR DESCRIPTION
'windowrulev2' is deprecated in hyprland 0.53.2 so i changed it a bit