### PR TITLE
Animated Wallpaper Support

### DIFF
--- a/src/share/sleex/modules/background/Background.qml
+++ b/src/share/sleex/modules/background/Background.qml
@@ -54,14 +54,14 @@ Scope {
                     id: currentWallpaper
                     anchors.fill: parent
                     fillMode: Image.PreserveAspectCrop
-                    opacity: 1.0
+                    playing: true
                 }
 
                 AnimatedImage {
                     id: previousWallpaper
                     anchors.fill: parent
                     fillMode: Image.PreserveAspectCrop
-                    opacity: 0.0
+                    playing: true
                 }
 
                 states: [
@@ -115,6 +115,9 @@ Scope {
 
                             previousWallpaper.source = wallpaperContainer.currentPath
                             currentWallpaper.source = newPath
+                            
+                            currentWallpaper.playing = false 
+                            currentWallpaper.playing = true
 
                             currentWallpaper.opacity = 0
                             previousWallpaper.opacity = 1
@@ -122,6 +125,7 @@ Scope {
                             wallpaperContainer.state = "crossfading"
                         } else {
                             currentWallpaper.source = newPath
+                            currentWallpaper.playing = true
                             wallpaperContainer.state = "showingCurrent"
                         }
 
@@ -137,7 +141,6 @@ Scope {
                     wallpaperContainer.state = "showingCurrent"
                 }
             }
-
 
             Clock {
                 id: clock

--- a/src/share/sleex/services/Wallpapers.qml
+++ b/src/share/sleex/services/Wallpapers.qml
@@ -16,7 +16,7 @@ Singleton {
         running: true
         command: [
             "bash", "-c",
-            "find " + root.wallpaperPath + " -type f \\( -iname '*.jpg' -o -iname '*.png' -o -iname '*.webp' \\) -printf '%P\\n'"
+            "find " + root.wallpaperPath + " -type f \\( -iname '*.jpg' -o -iname '*.png' -o -iname '*.gif' -o -iname '*.webp' \\) -printf '%P\\n'"
         ]
         stdout: StdioCollector {
             onStreamFinished: {


### PR DESCRIPTION
# Animated Wallpaper Support

- Added support within the wallpaper selector for GIFs.
- Animated wallpaper plays smoothly upon selection. Previously, you'd have to restart the shell.

## Saving as draft

- In it's current state, whenever you open the dashboard, there is a stutter. 
- When I have time and figure out how to fix this,  I'll change this from a draft.

## Demo
https://github.com/user-attachments/assets/8267d2ac-071d-466d-b1dd-86814927061e

