### PR TITLE
Better battery warnings

### DIFF
--- a/src/etc/sleex/hyprland/rules.conf
+++ b/src/etc/sleex/hyprland/rules.conf
@@ -99,3 +99,6 @@ layerrule = match:namespace quickshell:session, blur on
 layerrule = match:namespace quickshell:session, ignore_alpha 0
 layerrule = match:namespace quickshell:dashboard, animation slide bottom
 layerrule = match:namespace quickshell:wallpaperSelector, animation slide top
+layerrule = match:namespace quickshell:batterywarning, blur off
+layerrule = match:namespace quickshell:batterywarning, ignore_alpha 1
+layerrule = match:namespace quickshell:batterywarning, no_anim on

--- a/src/share/sleex/BatteryWarningOverlay.qml
+++ b/src/share/sleex/BatteryWarningOverlay.qml
@@ -1,0 +1,275 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Wayland
+
+Scope {
+    id: root
+
+    property bool isCritical: false
+
+    Connections {
+        target: Battery
+
+        function onIsLowAndNotChargingChanged() {
+            if (Battery.isLowAndNotCharging) {
+                root.isCritical = Battery.isCriticalAndNotCharging
+                overlayLoader.active = false
+                overlayLoader.loading = true
+                if (Config.options.battery.sound !== false) {
+                    Audio.playSound(root.isCritical
+                        ? "assets/sounds/battery/05_critical.wav"
+                        : "assets/sounds/battery/04_warn.wav")
+                }
+            } else {
+                root.isCritical = false
+                overlayLoader.active = false
+            }
+        }
+
+        function onIsCriticalAndNotChargingChanged() {
+            if (Battery.isCriticalAndNotCharging) {
+                root.isCritical = true
+                overlayLoader.active = false
+                overlayLoader.loading = true
+                if (Config.options.battery.sound !== false) {
+                    Audio.playSound("assets/sounds/battery/05_critical.wav")
+                }
+            }
+        }
+    }
+
+    LazyLoader {
+        id: overlayLoader
+
+        PanelWindow {
+            id: popupWindow
+            color: "transparent"
+
+            // Cover the entire screen
+            anchors.top:    true
+            anchors.bottom: true
+            anchors.left:   true
+            anchors.right:  true
+
+            exclusionMode: ExclusionMode.Ignore
+            exclusiveZone: 0
+
+            WlrLayershell.layer:         WlrLayer.Overlay
+            WlrLayershell.namespace:     "quickshell:batterywarning"
+            WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+
+            Rectangle {
+                anchors.fill: parent
+                color:        Appearance.m3colors.m3scrim
+                opacity:      0.45
+
+                NumberAnimation on opacity {
+                    from: 0; to: 0.45
+                    duration:           Appearance.animation.elementMoveEnter.duration
+                    easing.type:        Appearance.animation.elementMoveEnter.type
+                    easing.bezierCurve: Appearance.animation.elementMoveEnter.bezierCurve
+                }
+
+                // Tap outside the card to dismiss
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked:    overlayLoader.active = false
+                }
+            }
+
+            Item {
+                id: cardWrapper
+                anchors.centerIn: parent
+                width:  card.implicitWidth
+                height: card.implicitHeight
+                opacity: 0
+                scale:   0.85
+
+                ParallelAnimation {
+                    running: true
+                    NumberAnimation {
+                        target: cardWrapper; property: "opacity"
+                        from: 0; to: 1
+                        duration:           Appearance.animation.elementMoveEnter.duration
+                        easing.type:        Appearance.animation.elementMoveEnter.type
+                        easing.bezierCurve: Appearance.animation.elementMoveEnter.bezierCurve
+                    }
+                    NumberAnimation {
+                        target: cardWrapper; property: "scale"
+                        from: 0.85; to: 1.0
+                        duration:           Appearance.animation.elementMoveEnter.duration
+                        easing.type:        Appearance.animation.elementMoveEnter.type
+                        easing.bezierCurve: Appearance.animation.elementMoveEnter.bezierCurve
+                    }
+                }
+
+                StyledRectangularShadow {
+                    target: card
+                }
+
+                Rectangle {
+                    id: card
+                    implicitWidth:  320
+                    implicitHeight: cardColumn.implicitHeight
+                    radius:         Appearance.rounding.verylarge
+                    color:          Appearance.m3colors.m3surfaceContainerHigh
+                    clip:           true
+
+                    ColumnLayout {
+                        id: cardColumn
+                        width: parent.width
+                        spacing: 0
+
+                        ColumnLayout {
+                            Layout.fillWidth:    true
+                            Layout.topMargin:    32
+                            Layout.bottomMargin: 28
+                            Layout.leftMargin:   24
+                            Layout.rightMargin:  24
+                            spacing: 8
+
+                            MaterialSymbol {
+                                Layout.alignment: Qt.AlignHCenter
+                                text: Battery.percentageInt <= Battery.criticalThreshold
+                                    ? "battery_very_low"
+                                    : "battery_low"
+                                font.pixelSize: 52
+                                color: root.isCritical
+                                    ? Appearance.colors.colError
+                                    : Appearance.colors.colPrimary
+
+                                Behavior on color {
+                                    ColorAnimation {
+                                        duration:           Appearance.animation.elementMoveFast.duration
+                                        easing.type:        Appearance.animation.elementMoveFast.type
+                                        easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                    }
+                                }
+
+                                SequentialAnimation on opacity {
+                                    running: root.isCritical
+                                    loops:   Animation.Infinite
+                                    NumberAnimation { to: 0.25; duration: 600; easing.type: Easing.InOutSine }
+                                    NumberAnimation { to: 1.0;  duration: 600; easing.type: Easing.InOutSine }
+                                }
+                            }
+
+                            StyledText {
+                                Layout.fillWidth:    true
+                                horizontalAlignment: Text.AlignHCenter
+                                text:        root.isCritical ? qsTr("Critical Battery") : qsTr("Low Battery")
+                                font.family: Appearance.font.family.main
+                                font.pixelSize: Appearance.font.pixelSize.large
+                                font.weight: Font.Bold
+                                color:       Appearance.colors.colOnLayer2
+                            }
+
+                            StyledText {
+                                Layout.fillWidth:    true
+                                horizontalAlignment: Text.AlignHCenter
+                                text:        qsTr("%1% battery remaining.").arg(Battery.percentageInt)
+                                font.family: Appearance.font.family.main
+                                font.pixelSize: Appearance.font.pixelSize.small
+                                color:       Appearance.colors.colOnLayer1
+                                wrapMode:    Text.WordWrap
+                            }
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            height:  1
+                            color:   Appearance.colors.colOutlineVariant
+                            opacity: 0.5
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            implicitHeight:   54
+                            color: powerSaverHover.containsMouse
+                                ? Appearance.colors.colLayer2Hover
+                                : "transparent"
+
+                            Behavior on color {
+                                ColorAnimation {
+                                    duration:           Appearance.animation.elementMoveFast.duration
+                                    easing.type:        Appearance.animation.elementMoveFast.type
+                                    easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                }
+                            }
+
+                            StyledText {
+                                anchors.centerIn: parent
+                                text:             qsTr("Power Saver Mode")
+                                font.family:      Appearance.font.family.main
+                                font.pixelSize:   Appearance.font.pixelSize.normal
+                                font.weight:      Font.Medium
+                                color:            Appearance.colors.colPrimary
+                            }
+
+                            MouseArea {
+                                id:           powerSaverHover
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape:  Qt.PointingHandCursor
+                                onClicked: {
+                                    Quickshell.execDetached(["powerprofilesctl", "set", "power-saver"])
+                                    overlayLoader.active = false
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            height:  1
+                            color:   Appearance.colors.colOutlineVariant
+                            opacity: 0.5
+                        }
+
+                        Item {
+                            Layout.fillWidth: true
+                            implicitHeight:   54
+
+                            Rectangle {
+                                anchors.fill:        parent
+                                anchors.topMargin:   -Appearance.rounding.verylarge
+                                height:              parent.height + Appearance.rounding.verylarge
+                                radius:              Appearance.rounding.verylarge
+                                color: closeHover.containsMouse
+                                    ? Appearance.colors.colLayer2Hover
+                                    : "transparent"
+
+                                Behavior on color {
+                                    ColorAnimation {
+                                        duration:           Appearance.animation.elementMoveFast.duration
+                                        easing.type:        Appearance.animation.elementMoveFast.type
+                                        easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                    }
+                                }
+                            }
+
+                            StyledText {
+                                anchors.centerIn: parent
+                                text:             qsTr("Close")
+                                font.family:      Appearance.font.family.main
+                                font.pixelSize:   Appearance.font.pixelSize.normal
+                                color:            Appearance.colors.colPrimary
+                            }
+
+                            MouseArea {
+                                id:           closeHover
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape:  Qt.PointingHandCursor
+                                onClicked:    overlayLoader.active = false
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/share/sleex/modules/BatteryPopup/BatteryPopup.qml
+++ b/src/share/sleex/modules/BatteryPopup/BatteryPopup.qml
@@ -1,0 +1,235 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Wayland
+
+Scope {
+    id: root
+
+    property bool isCritical: false
+
+    component Divider: Rectangle {
+        Layout.fillWidth: true
+        height:  1
+        color:   Appearance.colors.colOutlineVariant
+        opacity: 0.5
+    }
+
+    component CardButton: Rectangle {
+        id: btn
+        required property string label
+        required property bool bold
+        signal clicked()
+
+        Layout.fillWidth: true
+        implicitHeight:   54
+        color: area.containsMouse ? Appearance.colors.colLayer2Hover : "transparent"
+
+        Behavior on color {
+            ColorAnimation {
+                duration:           Appearance.animation.elementMoveFast.duration
+                easing.type:        Appearance.animation.elementMoveFast.type
+                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+            }
+        }
+
+        StyledText {
+            anchors.centerIn: parent
+            text:             btn.label
+            font.pixelSize:   Appearance.font.pixelSize.normal
+            font.weight:      btn.bold ? Font.Medium : Font.Normal
+            color:            Appearance.colors.colPrimary
+        }
+
+        MouseArea {
+            id:           area
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape:  Qt.PointingHandCursor
+            onClicked:    btn.clicked()
+        }
+    }
+
+    Connections {
+        target: Battery
+
+        function onIsLowAndNotChargingChanged() {
+            if (!Config.options.battery.overlayEnabled) return
+            if (Battery.isLowAndNotCharging) {
+                root.isCritical = Battery.isCriticalAndNotCharging
+                overlayLoader.active = false
+                overlayLoader.loading = true
+                if (Config.options.battery.sound)
+                    Audio.playSound(root.isCritical
+                        ? "assets/sounds/battery/05_critical.wav"
+                        : "assets/sounds/battery/04_warn.wav")
+            } else {
+                root.isCritical = false
+                overlayLoader.active = false
+            }
+        }
+
+        function onIsCriticalAndNotChargingChanged() {
+            if (!Config.options.battery.overlayEnabled) return
+            if (Battery.isCriticalAndNotCharging) {
+                root.isCritical = true
+                overlayLoader.active = false
+                overlayLoader.loading = true
+                if (Config.options.battery.sound)
+                    Audio.playSound("assets/sounds/battery/05_critical.wav")
+            }
+        }
+    }
+    
+    LazyLoader {
+        id: overlayLoader
+
+        PanelWindow {
+            color: "transparent"
+
+            anchors { top: true; bottom: true; left: true; right: true }
+
+            exclusionMode: ExclusionMode.Ignore
+
+            WlrLayershell.layer:         WlrLayer.Overlay
+            WlrLayershell.namespace:     "quickshell:batterywarning"
+            WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+
+            Item {
+                anchors.fill: parent
+                focus: true
+
+                Keys.onPressed: (event) => {
+                    if (event.key === Qt.Key_Escape) {
+                        overlayLoader.active = false
+                        event.accepted = true
+                    }
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked:    overlayLoader.active = false
+                }
+
+                Item {
+                    id: cardWrapper
+                    anchors.centerIn: parent
+                    width:  card.implicitWidth
+                    height: card.implicitHeight
+
+                    opacity: 0
+                    scale:   0.85
+
+                    ParallelAnimation {
+                        running: true
+                        NumberAnimation {
+                            target:             cardWrapper
+                            property:           "opacity"
+                            from: 0; to: 1
+                            duration:           Appearance.animation.elementMoveEnter.duration
+                            easing.type:        Appearance.animation.elementMoveEnter.type
+                            easing.bezierCurve: Appearance.animation.elementMoveEnter.bezierCurve
+                        }
+                        NumberAnimation {
+                            target:             cardWrapper
+                            property:           "scale"
+                            from: 0.85; to: 1.0
+                            duration:           Appearance.animation.elementMoveEnter.duration
+                            easing.type:        Appearance.animation.elementMoveEnter.type
+                            easing.bezierCurve: Appearance.animation.elementMoveEnter.bezierCurve
+                        }
+                    }
+
+                    StyledRectangularShadow { target: card }
+
+                    Rectangle {
+                        id:             card
+                        implicitWidth:  320
+                        implicitHeight: cardColumn.implicitHeight
+                        radius:         Appearance.rounding.verylarge
+                        color:          Appearance.m3colors.m3surfaceContainerHigh
+                        clip:           true
+
+                        ColumnLayout {
+                            id:      cardColumn
+                            width:   parent.width
+                            spacing: 0
+                            ColumnLayout {
+                                Layout.fillWidth:    true
+                                Layout.topMargin:    32
+                                Layout.bottomMargin: 28
+                                Layout.leftMargin:   24
+                                Layout.rightMargin:  24
+                                spacing: 8
+
+                                MaterialSymbol {
+                                    Layout.alignment: Qt.AlignHCenter
+                                    text: Battery.percentageInt <= Battery.criticalThreshold
+                                        ? "battery_very_low" : "battery_low"
+                                    font.pixelSize: 52
+                                    color: root.isCritical
+                                        ? Appearance.colors.colError
+                                        : Appearance.colors.colPrimary
+
+                                    Behavior on color {
+                                        ColorAnimation {
+                                            duration:           Appearance.animation.elementMoveFast.duration
+                                            easing.type:        Appearance.animation.elementMoveFast.type
+                                            easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                                        }
+                                    }
+
+                                    SequentialAnimation on opacity {
+                                        running: root.isCritical
+                                        loops:   Animation.Infinite
+                                        NumberAnimation { to: 0.25; duration: 600; easing.type: Easing.InOutSine }
+                                        NumberAnimation { to: 1.0;  duration: 600; easing.type: Easing.InOutSine }
+                                    }
+                                }
+
+                                StyledText {
+                                    Layout.fillWidth:    true
+                                    horizontalAlignment: Text.AlignHCenter
+                                    text:       root.isCritical ? qsTr("Critical Battery") : qsTr("Low Battery")
+                                    font.pixelSize: Appearance.font.pixelSize.large
+                                    font.weight: Font.Bold
+                                    color:      Appearance.colors.colOnLayer2
+                                }
+
+                                StyledText {
+                                    Layout.fillWidth:    true
+                                    horizontalAlignment: Text.AlignHCenter
+                                    text:  qsTr("%1% battery remaining.").arg(Battery.percentageInt)
+                                    font.pixelSize: Appearance.font.pixelSize.small
+                                    color: Appearance.colors.colOnLayer1
+                                }
+                            }
+
+                            Divider {}
+
+                            CardButton {
+                                label: qsTr("Power Saver Mode")
+                                bold:  true
+                                onClicked: {
+                                    Quickshell.execDetached(["powerprofilesctl", "set", "power-saver"])
+                                    overlayLoader.active = false
+                                }
+                            }
+
+                            Divider {}
+
+                            CardButton {
+                                label:     qsTr("Close")
+                                bold:      false
+                                onClicked: overlayLoader.active = false
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/share/sleex/modules/common/Config.qml
+++ b/src/share/sleex/modules/common/Config.qml
@@ -148,6 +148,7 @@ Singleton {
             property int critical: 5
             property int suspend: 2
             property bool sound: true //Added for Battery Sound Toggle
+            property bool overlayEnabled: true
         }
 
         property JsonObject bar: JsonObject {

--- a/src/share/sleex/modules/settings/Interface.qml
+++ b/src/share/sleex/modules/settings/Interface.qml
@@ -466,6 +466,16 @@ ContentPage {
                 {"value": "top-right", "displayName": "Top Right"},
             ]
         }
+        
+        ConfigSwitch {
+            visible: UPower.displayDevice.isLaptopBattery
+            text: "Battery overlay warnings"
+            checked: Config.options.battery.overlayEnabled
+            onClicked: checked = !checked;
+            onCheckedChanged: {
+                Config.options.battery.overlayEnabled = checked;
+            }
+        }  
     }
 
     ContentSection {

--- a/src/share/sleex/services/Audio.qml
+++ b/src/share/sleex/services/Audio.qml
@@ -54,6 +54,6 @@ Singleton {
         const fullPath = "/usr/share/sleex/" + relativeSoundPath;
         // Use the absolute path to paplay to be safe.
         const command = ["/usr/bin/paplay", `${fullPath}`];
-        Quickshell.execDetached([command]);
+        Quickshell.execDetached(command);
     }
 }

--- a/src/share/sleex/services/Battery.qml
+++ b/src/share/sleex/services/Battery.qml
@@ -10,99 +10,89 @@ import Quickshell.Io
 Singleton {
     id: batteryService
 
-    property bool available: UPower.displayDevice.isLaptopBattery
-    property var chargeState: UPower.displayDevice.state
-    property bool isCharging: chargeState === UPowerDeviceState.Charging || chargeState === UPowerDeviceState.PendingCharge
+    property bool available:     UPower.displayDevice.isLaptopBattery
+    property var  chargeState:   UPower.displayDevice.state
+    property bool isCharging:    chargeState === UPowerDeviceState.Charging || chargeState === UPowerDeviceState.PendingCharge
     property bool isDischarging: chargeState === UPowerDeviceState.Discharging
-    property bool isPluggedIn: isCharging || chargeState === UPowerDeviceState.FullyCharged
-    property real percentage: UPower.displayDevice.percentage
+    property bool isPluggedIn:   isCharging || chargeState === UPowerDeviceState.FullyCharged
+
+    property real percentage:          UPower.displayDevice.percentage
     readonly property int percentageInt: Math.round(batteryService.percentage * 100)
 
-    property bool isLow: percentage <= Config.options.battery.low / 100
-    property bool isCritical: percentage <= Config.options.battery.critical / 100
-    property bool isSuspending: percentage <= Config.options.battery.suspend / 100
+    property bool isLow:        percentage <= Config.options.battery.low      / 100
+    property bool isCritical:   percentage <= Config.options.battery.critical / 100
+    property bool isSuspending: percentage <= Config.options.battery.suspend  / 100
 
-    property int warningThreshold: Config.options.battery.low
+    property int warningThreshold:  Config.options.battery.low
     property int criticalThreshold: Config.options.battery.critical
-    property int suspendThreshold: Config.options.battery.suspend
+    property int suspendThreshold:  Config.options.battery.suspend
 
-    property bool isLowAndNotCharging: isLow && !isCharging
+    property bool isLowAndNotCharging:      isLow      && !isCharging
     property bool isCriticalAndNotCharging: isCritical && !isCharging
 
-    property real energyRate: UPower.displayDevice.changeRate
-    property real timeToFull: UPower.displayDevice.timeToFull
+    property real energyRate:  UPower.displayDevice.changeRate
+    property real timeToFull:  UPower.displayDevice.timeToFull
     property real temperature: 0
 
     readonly property int remainingTime: {
-        const seconds = UPower.displayDevice.timeToFull;
-        return (seconds > 0 && isFinite(seconds)) ? Math.floor(seconds / 60) : 0;
+        const seconds = UPower.displayDevice.timeToFull
+        return (seconds > 0 && isFinite(seconds)) ? Math.floor(seconds / 60) : 0
     }
     readonly property int timeToEmpty: UPower.displayDevice.timeToEmpty
 
-    property bool _wasLow: false
-    property bool _wasCritical: false
-    property bool _wasSuspendWarned: false
     property bool _wasFull: false
 
     onIsPluggedInChanged: {
-        if (!available) return;
+        if (!available) return
         if (isPluggedIn) {
-            if (Config.options.battery.sound !== false) {
-                Audio.playSound("assets/sounds/battery/02_plug.wav");
-            }
-            _wasLow = false;
-            _wasCritical = false;
+            if (Config.options.battery.sound)
+                Audio.playSound("assets/sounds/battery/02_plug.wav")
         } else {
-            if (Config.options.battery.sound !== false) {
-                Audio.playSound("assets/sounds/battery/02_unplug.wav");
-            }
-            checkBatteryState();
+            if (Config.options.battery.sound)
+                Audio.playSound("assets/sounds/battery/02_unplug.wav")
         }
+    }
+
+    onIsDischargingChanged: {
+        if (isDischarging) _wasFull = false
     }
 
     onPercentageChanged: {
-        if (!available) return;
-        checkBatteryState();
+        if (!available) return
+        if (isPluggedIn) {
+            if (batteryService.percentageInt >= 100 && !_wasFull) {
+                _wasFull = true
+                if (Config.options.battery.sound)
+                    Audio.playSound("assets/sounds/battery/01_full.wav")
+                sendNotification("Battery Full", "The battery is fully charged.")
+            }
+            if (batteryService.percentageInt < 100) _wasFull = false
+        }
     }
 
-        // Rewritten for stateful, more intelligent notifications.
-    function checkBatteryState() {
-        if (isDischarging) {
-            _wasFull = false;
-
-            if (batteryService.percentageInt <= criticalThreshold && !_wasCritical) {
-                _wasCritical = true;
-                _wasLow = true;
-                if (Config.options.battery.sound !== false) {
-                    Audio.playSound("assets/sounds/battery/05_critical.wav");
-                }
-                sendNotification("Critical Battery Level", `Power level has reached ${batteryService.percentageInt}%. Please connect your charger immediately.`);
-            }
-            else if (batteryService.percentageInt <= warningThreshold && !_wasLow) {
-                _wasLow = true;
-                if (Config.options.battery.sound !== false) {
-                    Audio.playSound("assets/sounds/battery/04_warn.wav");
-                }
-                sendNotification("Low Battery Warning", `Power level has dropped to ${batteryService.percentageInt}%. Consider connecting your charger.`);
-            }
+    onIsCriticalAndNotChargingChanged: {
+        if (!available) return
+        if (isCriticalAndNotCharging && !Config.options.battery.overlayEnabled) {
+            if (Config.options.battery.sound)
+                Audio.playSound("assets/sounds/battery/05_critical.wav")
+            sendNotification("Critical Battery Level",
+                `Power level has reached ${batteryService.percentageInt}%. Please connect your charger immediately.`)
         }
+    }
 
-        if (isPluggedIn) {
-            if (batteryService.percentageInt > warningThreshold) _wasLow = false;
-            if (batteryService.percentageInt > criticalThreshold) _wasCritical = false;
-
-            if (batteryService.percentageInt >= 100 && !_wasFull) {
-                _wasFull = true;
-                if (Config.options.battery.sound !== false) {
-                    Audio.playSound("assets/sounds/battery/01_full.wav");
-                }
-                sendNotification("Battery Full", "The battery is fully charged.");
-            }
+    onIsLowAndNotChargingChanged: {
+        if (!available) return
+        // Only fire for low (not critical) to avoid double notification
+        if (isLowAndNotCharging && !isCriticalAndNotCharging && !Config.options.battery.overlayEnabled) {
+            if (Config.options.battery.sound)
+                Audio.playSound("assets/sounds/battery/04_warn.wav")
+            sendNotification("Low Battery Warning",
+                `Power level has dropped to ${batteryService.percentageInt}%. Consider connecting your charger.`)
         }
     }
 
     function sendNotification(title, body) {
-        Quickshell.execDetached(["notify-send", `${title}`, `${body}`, "-u", "critical", "-a", "System"]);
+        Quickshell.execDetached(["notify-send", title, body, "-u", "critical", "-a", "System"])
     }
 
     Process {
@@ -110,30 +100,21 @@ Singleton {
         command: ["bash", "-c", "cat /sys/class/thermal/thermal_zone0/temp"]
         stdout: StdioCollector {
             onStreamFinished: {
-                if (text && text.trim() !== "") {
-                    Battery.temperature = parseInt(text.trim()) / 1000
-                } else {
-                    Battery.temperature = 0
-                }
+                Battery.temperature = text && text.trim() !== ""
+                    ? parseInt(text.trim()) / 1000
+                    : 0
             }
         }
     }
 
     Timer {
         interval: 3000
-        repeat: true
-        running: true
-        onTriggered: {
-            if (!tempProcess.running) {
-                tempProcess.running = true
-            }
-        }
+        repeat:   true
+        running:  true
+        onTriggered: if (!tempProcess.running) tempProcess.running = true
     }
 
     Component.onCompleted: {
-        if (!tempProcess.running) {
-            tempProcess.running = true;
-        }
+        if (!tempProcess.running) tempProcess.running = true
     }
-
 }

--- a/src/share/sleex/shell.qml
+++ b/src/share/sleex/shell.qml
@@ -22,6 +22,7 @@ import qs.modules.sidebarLeft
 import qs.modules.wallpaperSelector
 import qs.modules.background
 import qs.modules.lockscreen
+import qs.modules.BatteryPopup
 
 import Quickshell
 import QtQuick
@@ -69,6 +70,7 @@ ShellRoot {
     LazyLoader { active: enableOverview; component: Overview {} }
     LazyLoader { active: enablePolkit; component: Polkit {} }
     LazyLoader { active: enableReloadPopup; component: ReloadPopup {} }
+    LazyLoader { active: true; component: BatteryPopup {} }
     LazyLoader { active: enableScreenCorners; component: ScreenCorners {} }
     LazyLoader { active: enableSession; component: Session {} }
     LazyLoader { active: enableSidebarLeft; component: SidebarLeft {} }


### PR DESCRIPTION
## Battery Warning Overlay

### Summary & Demo
Replaces the notify-send battery alerts with a more aesthetically pleasing overlay that renders above fullscreen windows via `WlrLayer.Overlay`, completely independent of the notification daemon.

https://github.com/user-attachments/assets/098e48f2-8cb8-4272-95e5-48440290071b

### Problem
Battery low/critical notifications were suppressed by silent/DND mode, meaning the laptop could die unnoticed, especially during fullscreen video playback or playing fullscreen games -etc where the bar is hidden. Also, this just looks much better.

### Solution
A new `BatteryWarningOverlay.qml` component listens directly to the `Battery` service and presents a centered dialog that:
- Always appears above fullscreen content (WlrLayer.Overlay)
- Is never suppressed by silent mode
- Escalates from warning to critical styling automatically
- Offers **Power Saver Mode** (enables `power-saver` via powerprofilesctl) and **Close** as actions
- Plays battery sounds respecting the existing "Enable battery notification sounds" setting in Sound preferences

### Changes
- **`BatteryWarningOverlay.qml`** — new overlay component
- **`shell.qml`** — registers the overlay via `LazyLoader`
- **`services/Battery.qml`** — removes low/critical `notify-send` calls and sound dispatch (now owned by the overlay)
- **`services/Audio.qml`** — fixes a pre-existing bug where `Quickshell.execDetached([command])` was passing a nested array, causing all `playSound` calls to silently fail

### Notes
- The "Battery Full" notification and plug/unplug sounds in `Battery.qml` are unchanged
- The overlay can be disabled via `enableBatteryWarningOverlay: false` in `shell.qml` without affecting anything else. I suppose you could also set Behaviour > Low Warning / Critical Warning to 0 to bypass the overlay.
- Requires `powerprofilesctl` for the Power Saver action which is fine since AxOS already comes with this pre-installed.