### PR TITLE
Fix issues with Bibata being in Sleex dependency tree

### DIFF
--- a/sleex-packages/sleex-bibata-modern-classic-bin/PKGBUILD
+++ b/sleex-packages/sleex-bibata-modern-classic-bin/PKGBUILD
@@ -1,10 +1,11 @@
 pkgname=sleex-bibata-modern-classic-bin
-pkgver=2.0.6
+pkgver=2.0.7
 pkgrel=3
 pkgdesc="Material Based Cursor Theme, installed for Sleex"
 arch=('any')
 url="https://github.com/ful1e5/Bibata_Cursor"
 license=('GPL-3.0-or-later')
+provides=("bibata-cursor-theme" "bibata-cursor-theme-bin")
 conflicts=("bibata-cursor-theme" "bibata-cursor-theme-bin")
 options=('!strip')
 _variant=Bibata-Modern-Classic


### PR DESCRIPTION
I presume that `bibata-cursor-theme-bin` is appearing in the dependency tree of Sleex and causing issues as `sleex-bibata-modern-classic-bin` conflicts with it. This PR fixes this issue by adding both `bibata-cursor-theme` and `bibata-cursor-theme-bin` in provides.