### PR TITLE
fix: adapt Sleex to work on runit systems (for Kira Linux)

### DIFF
--- a/sleex-user-config/src/.config/hypr/hypridle.conf
+++ b/sleex-user-config/src/.config/hypr/hypridle.conf
@@ -32,5 +32,5 @@ listener {
 
 listener {
     timeout = 600                      # 10min
-    on-timeout = systemctl suspend     # suspend pc
+    on-timeout = loginctl suspend      # suspend pc
 }

--- a/sleex-user-config/src/.config/wlogout/layout
+++ b/sleex-user-config/src/.config/wlogout/layout
@@ -6,7 +6,7 @@
 }
 {
     "label" : "hibernate",
-    "action" : "systemctl hibernate || loginctl hibernate",
+    "action" : "loginctl hibernate",
     "text" : "save",
     "keybind" : "h"
 }
@@ -18,19 +18,19 @@
 }
 {
     "label" : "shutdown",
-    "action" : "systemctl poweroff || loginctl poweroff",
+    "action" : "loginctl poweroff",
     "text" : "power_settings_new",
     "keybind" : "s"
 }
 {
     "label" : "suspend",
-    "action" : "systemctl suspend || loginctl suspend",
+    "action" : "loginctl suspend",
     "text" : "bedtime",
     "keybind" : "u"
 }
 {
     "label" : "reboot",
-    "action" : "systemctl reboot || loginctl reboot",
+    "action" : "loginctl reboot",
     "text" : "restart_alt",
     "keybind" : "r"
 }

--- a/src/bin/sleex
+++ b/src/bin/sleex
@@ -1,9 +1,14 @@
 #!/bin/sh
 export XDG_CURRENT_DESKTOP="Sleex"
 export HYPRLAND_INSTANCE_SIGNATURE=""
-systemctl --user import-environment XDG_CURRENT_DESKTOP
 
-systemctl --user start sleex-lock-listener.service
+# systemctl --user only exists on systemd; use dbus directly otherwise
+if [ -d /run/systemd/system ]; then
+    systemctl --user import-environment XDG_CURRENT_DESKTOP
+    systemctl --user start sleex-lock-listener.service
+else
+    dbus-update-activation-environment XDG_CURRENT_DESKTOP
+fi
 
 # Check if config dirs/files exist, if not copy them from /etc/skel
 for dir in fish hypr anyrun fuzzel Kvantum matugen vdirsyncer kde-material-you-colors mpv wlogout qt5ct xdg-desktop-portal fontconfig khal qt6ct zshrc.d foot; do

--- a/src/etc/sleex/hyprland/execs.lua
+++ b/src/etc/sleex/hyprland/execs.lua
@@ -1,7 +1,7 @@
 hl.on("hyprland.start", function () 
     -- Bar, wallpaper
     -- hl.dsp.exec_cmd("swww-daemon")
-    hl.exec_cmd("qs -p /usr/share/sleex &")
+    hl.exec_cmd("QT_QPA_PLATFORM=wayland qs -p /usr/share/sleex &")
 
     -- Core components (authentication, lock screen, notification daemon)
     hl.exec_cmd("dbus-update-activation-environment --all")

--- a/src/share/sleex/greetd.qml
+++ b/src/share/sleex/greetd.qml
@@ -370,7 +370,7 @@ ShellRoot {
                             color: Appearance.colors.colOnLayer0
                             anchors.centerIn: parent
                         }
-                        onClicked: Quickshell.execDetached(["systemctl", "suspend"])
+                        onClicked: Quickshell.execDetached(["loginctl", "suspend"])
                     }
                     
                     RippleButton {
@@ -385,7 +385,7 @@ ShellRoot {
                             anchors.centerIn: parent
                             color: Appearance.colors.colOnLayer0
                         }
-                        onClicked: Quickshell.execDetached(["systemctl", "reboot"])
+                        onClicked: Quickshell.execDetached(["loginctl", "reboot"])
                     }
 
                     RippleButton {
@@ -401,7 +401,7 @@ ShellRoot {
                             anchors.centerIn: parent
                             color: Appearance.colors.colOnLayer0
                         }
-                        onClicked: Quickshell.execDetached(["systemctl", "poweroff"])
+                        onClicked: Quickshell.execDetached(["loginctl", "poweroff"])
                     }
                 }
             }

--- a/src/share/sleex/modules/common/Idle.qml
+++ b/src/share/sleex/modules/common/Idle.qml
@@ -70,7 +70,7 @@ Singleton {
                 }
                 property JsonObject suspend: JsonObject {
                     property int timeout: 300
-                    property string actions: "systemctl suspend"
+                    property string actions: "loginctl suspend"
                     property bool on_battery: true
                     property bool enabled: true
                 }

--- a/src/share/sleex/modules/lockscreen/LockSurface.qml
+++ b/src/share/sleex/modules/lockscreen/LockSurface.qml
@@ -444,7 +444,7 @@ FocusScope {
                         Layout.fillHeight: true; Layout.fillWidth: true
                         buttonRadius: Appearance.rounding.full
                         MaterialSymbol { text: "bedtime"; iconSize: 20; anchors.centerIn: parent; color: Appearance.colors.colOnLayer0 }
-                        onClicked: Quickshell.execDetached(["systemctl", "suspend"])
+                        onClicked: Quickshell.execDetached(["loginctl", "suspend"])
                     }
                     RippleButton {
                         colBackground: Appearance.colors.colLayer1
@@ -452,14 +452,14 @@ FocusScope {
                         Layout.fillHeight: true; Layout.fillWidth: true
                         buttonRadius: Appearance.rounding.full
                         MaterialSymbol { text: "power_settings_new"; iconSize: 20; anchors.centerIn: parent; color: Appearance.colors.colOnLayer0 }
-                        onClicked: Quickshell.execDetached(["systemctl", "poweroff"])
+                        onClicked: Quickshell.execDetached(["loginctl", "poweroff"])
                     }
                     RippleButton {
                         colBackground: Appearance.colors.colLayer1
                         Layout.fillHeight: true; Layout.fillWidth: true
                         buttonRadius: Appearance.rounding.full
                         MaterialSymbol { text: "restart_alt"; iconSize: 20; anchors.centerIn: parent; color: Appearance.colors.colOnLayer0 }
-                        onClicked: Quickshell.execDetached(["systemctl", "reboot"])
+                        onClicked: Quickshell.execDetached(["loginctl", "reboot"])
                     }
                 }
             }

--- a/src/share/sleex/modules/session/Session.qml
+++ b/src/share/sleex/modules/session/Session.qml
@@ -160,7 +160,7 @@ Scope {
                         id: sessionFirmwareReboot
                         buttonIcon: "settings_applications"
                         buttonText: qsTr("Reboot to firmware settings")
-                        onClicked: Quickshell.execDetached(["loginctl", "reboot", "--firmware-setup"]);
+                        onClicked: Quickshell.execDetached(["systemctl", "reboot", "--firmware-setup"]);
                         onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
                         KeyNavigation.up: sessionTaskManager
                         KeyNavigation.left: sessionReboot

--- a/src/share/sleex/modules/session/Session.qml
+++ b/src/share/sleex/modules/session/Session.qml
@@ -90,89 +90,98 @@ Scope {
                     }
                 }
 
-                GridLayout {
-                    columns: 4
-                    columnSpacing: 15
-                    rowSpacing: 15
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: 15
 
-                    SessionActionButton {
-                        id: sessionLock
-                        focus: sessionRoot.visible
-                        buttonIcon: "lock"
-                        buttonText: qsTr("Lock")
-                        onClicked:  GlobalStates.screenLocked = true;
-                        onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
-                        KeyNavigation.right: sessionSleep
-                        KeyNavigation.down: sessionHibernate
-                    }
-                    SessionActionButton {
-                        id: sessionSleep
-                        buttonIcon: "dark_mode"
-                        buttonText: qsTr("Sleep")
-                        onClicked:  { Quickshell.execDetached(["loginctl", "suspend"]); sessionRoot.hide() }
-                        onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
-                        KeyNavigation.left: sessionLock
-                        KeyNavigation.right: sessionLogout
-                        KeyNavigation.down: sessionShutdown
-                    }
-                    SessionActionButton {
-                        id: sessionLogout
-                        buttonIcon: "logout"
-                        buttonText: qsTr("Logout")
-                        onClicked: { Quickshell.execDetached(["pkill", "Hyprland"]); sessionRoot.hide() }
-                        onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
-                        KeyNavigation.left: sessionSleep
-                        KeyNavigation.right: sessionTaskManager
-                        KeyNavigation.down: sessionReboot
-                    }
-                    SessionActionButton {
-                        id: sessionTaskManager
-                        buttonIcon: "browse_activity"
-                        buttonText: qsTr("Task Manager")
-                        onClicked:  { Quickshell.execDetached(["bash", "-c", `${Config.options.apps.taskManager}`]); sessionRoot.hide() }
-                        onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
-                        KeyNavigation.left: sessionLogout
-                        KeyNavigation.down: root.hasSystemd ? sessionFirmwareReboot : null
+                    RowLayout {
+                        Layout.alignment: Qt.AlignHCenter
+                        spacing: 15
+
+                        SessionActionButton {
+                            id: sessionLock
+                            focus: sessionRoot.visible
+                            buttonIcon: "lock"
+                            buttonText: qsTr("Lock")
+                            onClicked:  GlobalStates.screenLocked = true;
+                            onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
+                            KeyNavigation.right: sessionSleep
+                            KeyNavigation.down: sessionHibernate
+                        }
+                        SessionActionButton {
+                            id: sessionSleep
+                            buttonIcon: "dark_mode"
+                            buttonText: qsTr("Sleep")
+                            onClicked:  { Quickshell.execDetached(["loginctl", "suspend"]); sessionRoot.hide() }
+                            onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
+                            KeyNavigation.left: sessionLock
+                            KeyNavigation.right: sessionLogout
+                            KeyNavigation.down: sessionShutdown
+                        }
+                        SessionActionButton {
+                            id: sessionLogout
+                            buttonIcon: "logout"
+                            buttonText: qsTr("Logout")
+                            onClicked: { Quickshell.execDetached(["pkill", "Hyprland"]); sessionRoot.hide() }
+                            onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
+                            KeyNavigation.left: sessionSleep
+                            KeyNavigation.right: sessionTaskManager
+                            KeyNavigation.down: sessionReboot
+                        }
+                        SessionActionButton {
+                            id: sessionTaskManager
+                            buttonIcon: "browse_activity"
+                            buttonText: qsTr("Task Manager")
+                            onClicked:  { Quickshell.execDetached(["bash", "-c", `${Config.options.apps.taskManager}`]); sessionRoot.hide() }
+                            onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
+                            KeyNavigation.left: sessionLogout
+                            KeyNavigation.down: root.hasSystemd ? sessionFirmwareReboot : null
+                        }
                     }
 
-                    SessionActionButton {
-                        id: sessionHibernate
-                        buttonIcon: "downloading"
-                        buttonText: qsTr("Hibernate")
-                        onClicked: Quickshell.execDetached(["loginctl", "hibernate"]);
-                        onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
-                        KeyNavigation.up: sessionLock
-                        KeyNavigation.right: sessionShutdown
-                    }
-                    SessionActionButton {
-                        id: sessionShutdown
-                        buttonIcon: "power_settings_new"
-                        buttonText: qsTr("Shutdown")
-                        onClicked: Quickshell.execDetached(["loginctl", "poweroff"])
-                        onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
-                        KeyNavigation.left: sessionHibernate
-                        KeyNavigation.right: sessionReboot
-                        KeyNavigation.up: sessionSleep
-                    }
-                    SessionActionButton {
-                        id: sessionReboot
-                        buttonIcon: "restart_alt"
-                        buttonText: qsTr("Reboot")
-                        onClicked: Quickshell.execDetached(["reboot"]);
-                        onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
-                        KeyNavigation.left: sessionShutdown
-                        KeyNavigation.right: root.hasSystemd ? sessionFirmwareReboot : null
-                        KeyNavigation.up: sessionLogout
-                    }
-                    SessionActionButton {
-                        id: sessionFirmwareReboot
-                        visible: root.hasSystemd
-                        buttonIcon: "settings_applications"
-                        buttonText: qsTr("Reboot to firmware settings")
-                        onClicked: Quickshell.execDetached(["systemctl", "reboot", "--firmware-setup"]);
-                        onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
-                        KeyNavigation.up: sessionTaskManager
-                        KeyNavigation.left: sessionReboot
+                    RowLayout {
+                        Layout.alignment: Qt.AlignHCenter
+                        spacing: 15
+
+                        SessionActionButton {
+                            id: sessionHibernate
+                            buttonIcon: "downloading"
+                            buttonText: qsTr("Hibernate")
+                            onClicked: Quickshell.execDetached(["loginctl", "hibernate"]);
+                            onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
+                            KeyNavigation.up: sessionLock
+                            KeyNavigation.right: sessionShutdown
+                        }
+                        SessionActionButton {
+                            id: sessionShutdown
+                            buttonIcon: "power_settings_new"
+                            buttonText: qsTr("Shutdown")
+                            onClicked: Quickshell.execDetached(["loginctl", "poweroff"])
+                            onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
+                            KeyNavigation.left: sessionHibernate
+                            KeyNavigation.right: sessionReboot
+                            KeyNavigation.up: sessionSleep
+                        }
+                        SessionActionButton {
+                            id: sessionReboot
+                            buttonIcon: "restart_alt"
+                            buttonText: qsTr("Reboot")
+                            onClicked: Quickshell.execDetached(["reboot"]);
+                            onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
+                            KeyNavigation.left: sessionShutdown
+                            KeyNavigation.right: root.hasSystemd ? sessionFirmwareReboot : null
+                            KeyNavigation.up: sessionLogout
+                        }
+                        SessionActionButton {
+                            id: sessionFirmwareReboot
+                            visible: root.hasSystemd
+                            buttonIcon: "settings_applications"
+                            buttonText: qsTr("Reboot to firmware settings")
+                            onClicked: Quickshell.execDetached(["systemctl", "reboot", "--firmware-setup"]);
+                            onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
+                            KeyNavigation.up: sessionTaskManager
+                            KeyNavigation.left: sessionReboot
+                        }
                     }
                 }
 

--- a/src/share/sleex/modules/session/Session.qml
+++ b/src/share/sleex/modules/session/Session.qml
@@ -14,6 +14,14 @@ import Quickshell.Hyprland
 Scope {
     id: root
     property var focusedScreen: Quickshell.screens.find(s => s.name === Hyprland.focusedMonitor?.name)
+    property bool hasSystemd: false
+
+    Process {
+        id: systemdCheck
+        running: true
+        command: ["test", "-d", "/run/systemd/system"]
+        onExited: (exitCode) => root.hasSystemd = (exitCode === 0)
+    }
 
     Loader {
         id: sessionLoader
@@ -124,7 +132,7 @@ Scope {
                         onClicked:  { Quickshell.execDetached(["bash", "-c", `${Config.options.apps.taskManager}`]); sessionRoot.hide() }
                         onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
                         KeyNavigation.left: sessionLogout
-                        KeyNavigation.down: sessionFirmwareReboot
+                        KeyNavigation.down: root.hasSystemd ? sessionFirmwareReboot : null
                     }
 
                     SessionActionButton {
@@ -153,11 +161,12 @@ Scope {
                         onClicked: Quickshell.execDetached(["reboot"]);
                         onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
                         KeyNavigation.left: sessionShutdown
-                        KeyNavigation.right: sessionFirmwareReboot
+                        KeyNavigation.right: root.hasSystemd ? sessionFirmwareReboot : null
                         KeyNavigation.up: sessionLogout
                     }
                     SessionActionButton {
                         id: sessionFirmwareReboot
+                        visible: root.hasSystemd
                         buttonIcon: "settings_applications"
                         buttonText: qsTr("Reboot to firmware settings")
                         onClicked: Quickshell.execDetached(["systemctl", "reboot", "--firmware-setup"]);

--- a/src/share/sleex/modules/session/Session.qml
+++ b/src/share/sleex/modules/session/Session.qml
@@ -101,7 +101,7 @@ Scope {
                         id: sessionSleep
                         buttonIcon: "dark_mode"
                         buttonText: qsTr("Sleep")
-                        onClicked:  { Quickshell.execDetached(["systemctl", "suspend"]); sessionRoot.hide() }
+                        onClicked:  { Quickshell.execDetached(["loginctl", "suspend"]); sessionRoot.hide() }
                         onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
                         KeyNavigation.left: sessionLock
                         KeyNavigation.right: sessionLogout
@@ -131,7 +131,7 @@ Scope {
                         id: sessionHibernate
                         buttonIcon: "downloading"
                         buttonText: qsTr("Hibernate")
-                        onClicked: Quickshell.execDetached(["systemctl", "hibernate"]);
+                        onClicked: Quickshell.execDetached(["loginctl", "hibernate"]);
                         onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
                         KeyNavigation.up: sessionLock
                         KeyNavigation.right: sessionShutdown
@@ -140,7 +140,7 @@ Scope {
                         id: sessionShutdown
                         buttonIcon: "power_settings_new"
                         buttonText: qsTr("Shutdown")
-                        onClicked: Quickshell.execDetached(["systemctl", "poweroff"])
+                        onClicked: Quickshell.execDetached(["loginctl", "poweroff"])
                         onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
                         KeyNavigation.left: sessionHibernate
                         KeyNavigation.right: sessionReboot
@@ -160,7 +160,7 @@ Scope {
                         id: sessionFirmwareReboot
                         buttonIcon: "settings_applications"
                         buttonText: qsTr("Reboot to firmware settings")
-                        onClicked: Quickshell.execDetached(["systemctl", "reboot", "--firmware-setup"]);
+                        onClicked: Quickshell.execDetached(["loginctl", "reboot", "--firmware-setup"]);
                         onFocusChanged: { if (focus) sessionRoot.subtitle = buttonText }
                         KeyNavigation.up: sessionTaskManager
                         KeyNavigation.left: sessionReboot

--- a/src/share/sleex/services/Idle.qml
+++ b/src/share/sleex/services/Idle.qml
@@ -71,7 +71,7 @@ Singleton {
                 }
                 property JsonObject suspend: JsonObject {
                     property int timeout: 300
-                    property string actions: "systemctl suspend"
+                    property string actions: "loginctl suspend"
                     property bool on_battery: true
                     property bool enabled: true
                 }


### PR DESCRIPTION
Sleex currently hard-depends on `systemctl` in a few places, which don't exist on non-systemd init systems (runit, in my case: Kira Linux). This makes Sleex fail outright on those systems even though nothing here actually needs systemd specifically.

- `src/bin/sleex`: only call `systemctl --user` (env import + starting `sleex-lock-listener.service`) when a systemd user manager is actually present (`/run/systemd/system` check); fall back to `dbus-update-activation-environment` directly otherwise.
- Everywhere else (`greetd.qml`, `Idle.qml`, `LockSurface.qml`, `Session.qml`, `hypridle.conf`, `wlogout/layout`): replaced `systemctl suspend/poweroff/reboot/hibernate` with `loginctl` equivalents. `loginctl` talks to the same `org.freedesktop.login1` D-Bus API whether it's backed by systemd-logind or elogind, so this works identically on both systemd and non-systemd systems. No behavior change on systemd, it just stops assuming systemd's service manager is the only way to reach logind.
- Tested on Kira Linux (runit + elogind); doesn't touch anything systemd-specific behavior depends on, so it should be a no-op for existing systemd users.