### PR TITLE
Dashboard Optimisation

### DIFF
--- a/src/share/sleex/modules/dashboard/Dashboard.qml
+++ b/src/share/sleex/modules/dashboard/Dashboard.qml
@@ -81,19 +81,13 @@ Scope {
                 height: 900
                 scale: dashboardScale
 
-                property bool contentActive: false
+                property bool contentActive: true
                 property bool isAnimating: false
                 property bool slideAnimEnabled: false
                 property bool showAtCenter: false
 
                 property string animDir: Config.options.dashboard.animationDirection
                 property int animDuration: Config.options.dashboard.animationDuration
-
-                Component.onCompleted: {
-                    if (GlobalStates.dashboardOpen) {
-                        scaleWrapper.contentActive = true
-                    }
-                }
 
                 readonly property int offX: animDir === "left"  ? -dashboardRoot.width  / dashboardScale
                                             : animDir === "right" ? dashboardRoot.width  / dashboardScale : 0
@@ -104,12 +98,10 @@ Scope {
                     target: GlobalStates
                     function onDashboardOpenChanged() {
                         if (GlobalStates.dashboardOpen) {
-                            closeHoldTimer.stop()
+                            closeHoldTimer.restart()
                             scaleWrapper.isAnimating = true
                             scaleWrapper.contentActive = true
-                            if (dashboardContentLoader.status === Loader.Ready) {
-                                scaleWrapper.showAtCenter = true
-                            }
+                            scaleWrapper.showAtCenter = true
                         } else {
                             scaleWrapper.showAtCenter = false
                             closeHoldTimer.restart()
@@ -121,7 +113,6 @@ Scope {
                     interval: Config.options.dashboard.animationDuration + 50
                     onTriggered: {
                         scaleWrapper.isAnimating = false
-                        scaleWrapper.contentActive = false
                     }
                 }
 
@@ -140,16 +131,12 @@ Scope {
                     asynchronous: true
                     visible: (GlobalStates.dashboardOpen && dashboardRoot.monitorIsFocused) || scaleWrapper.isAnimating
 
-                    layer.enabled: (GlobalStates.dashboardOpen && dashboardRoot.monitorIsFocused) || scaleWrapper.isAnimating
+                    layer.enabled: scaleWrapper.isAnimating
                     layer.smooth: true
 
                     onLoaded: {
-                        if (!GlobalStates.dashboardOpen) return
-                        scaleWrapper.slideAnimEnabled = false
-                        scaleWrapper.showAtCenter = false
                         Qt.callLater(() => {
                             scaleWrapper.slideAnimEnabled = true
-                            scaleWrapper.showAtCenter = true
                         })
                     }
 

--- a/src/share/sleex/modules/mediaControls/MediaControls.qml
+++ b/src/share/sleex/modules/mediaControls/MediaControls.qml
@@ -17,6 +17,7 @@ import Quickshell.Hyprland
 Item {
     id: root
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
+    readonly property bool windowShown: Window.window?.visible ?? false
     readonly property var realPlayers: Mpris.players.values.filter(player => isRealPlayer(player))
     readonly property var meaningfulPlayers: filterDuplicatePlayers(realPlayers)
     readonly property real osdWidth: Appearance.sizes.osdWidth
@@ -72,7 +73,7 @@ Item {
 
     Process {
         id: cavaProc
-        running: root.visible
+        running: root.windowShown
         onRunningChanged: {
             if (!cavaProc.running) {
                 root.visualizerPoints = [];

--- a/src/share/sleex/modules/mediaControls/PlayerControl.qml
+++ b/src/share/sleex/modules/mediaControls/PlayerControl.qml
@@ -1,3 +1,4 @@
+import qs
 import qs.modules.common
 import SleexUiKit.Widgets
 import qs.services
@@ -397,7 +398,7 @@ Item {
     }
 
     Timer {
-        running: player?.playbackState == MprisPlaybackState.Playing
+        running: player?.playbackState == MprisPlaybackState.Playing && (GlobalStates.dashboardOpen || playerController.isLockscreen)
         interval: 100; repeat: true
         onTriggered: player.positionChanged()
     }

--- a/src/share/sleex/services/CalendarService.qml
+++ b/src/share/sleex/services/CalendarService.qml
@@ -250,7 +250,7 @@ Singleton {
 
     Process {
         id: syncProcess
-        running: Config.options.dashboard.calendar.useVdirsyncer && !getEventsProcess.running
+        running: false
         command: ["vdirsyncer", "sync"]
         onExited: (exitCode) => {
             if (exitCode === 0) {

--- a/src/share/sleex/shell.qml
+++ b/src/share/sleex/shell.qml
@@ -65,7 +65,6 @@ ShellRoot {
     LazyLoader { active: enableBar; component: Bar {} }
     LazyLoader { active: enableCheatsheet; component: Cheatsheet {} }
     LazyLoader { active: enableDock && Config.options.dock.enabled; component: Dock {} }
-    LazyLoader { active: enableMediaControls; component: MediaControls {} }
     LazyLoader { active: enableNotificationPopup; component: NotificationPopup {} }
     LazyLoader { active: enableOnScreenDisplayBrightness; component: OnScreenDisplayBrightness {} }
     LazyLoader { active: enableOnScreenDisplayVolume; component: OnScreenDisplayVolume {} }


### PR DESCRIPTION
# Dashboard Optimisation

## The Problem
The dashboard is NOT appearing instantly upon toggle. It makes the UI feel sluggish.  Toggling the dashboard `(quickshell:dashboardToggle)` took several seconds to show anything. Opening it felt like a cold start every single time, even though the shell itself had been running for hours.

## Root causes

1. The entire dashboard content was torn down and rebuilt on every close. A `closeHoldTimer` set `contentActive = false` ~400 ms after closing, which destroyed the whole widget tree (home widgets, calendar, todo lists, notifications, media controls) and forced a full reconstruction on every subsequent open.

2. The open animation was gated on content loading. The content Loader was `asynchronous: true` and the slide-in animation only started in `onLoaded`, so the window appeared as an empty transparent overlay for the entire build time, then the animation started.

3. A fullscreen off-screen layer stayed enabled the whole time the dashboard was open, forcing the entire 1500×900 dashboard to re-render into an FBO texture on every change (clock tick, hover, notification update, visualizer frame).

4. Resources ran while invisible. The cava audio visualizer process and a 100 ms MPRIS position-poll timer ran whenever a player existed — even with the dashboard closed and on hidden, windowless widget instances.

5. `CalendarService` had an infinite `vdirsyncer` sync loop whenever `useVdirsyncer` was enabled (every events reload immediately triggered another sync).

6. A dead, invisible `MediaControls` instance lived in the shell root, instantiating a full hidden `PlayerControl` tree (images, blur layers, color quantizer) whenever any MPRIS player existed.

## Fixes

- `Dashboard.qml` — content preloaded and kept alive; instant, GPU-cheap animations. Content now loads once at shell startup (`contentActive: true` by default) and is never destroyed on close — every open after the first is instant, with zero rebuild cost.

- MediaControls.qml — `visualizer` only runs on screen

- PlayerControl.qml — The 100 ms position-update timer now only runs while the dashboard is open or the widget is on the lockscreen, instead of forever whenever a player was playing.

- CalendarService.qml — Fixed infinite sync loop. `syncProcess` no longer auto-restarts via a running binding; `vdirsyncer` sync now runs only on explicit triggers (initial sync, the 10-minute interval timer, and the manual sync button). Previously it looped endlessly: sync → load events → sync → …

- shell.qml — Removed the invisible shell-root `LazyLoader { component: MediaControls {} }`, which had no window to render into but still created a full hidden `PlayerControl` tree (image loads, blur layers, color quantizer, timers) whenever a player existed. The dashboard and lockscreen instantiate their own `MediaControls` as needed.


## Impact
- Dashboard opens instantly on the first and every subsequent toggle.
- No per-open teardown/rebuild churn (no more cava spawn/kill per toggle, no widget reconstruction, no repeated image/service re-initialization).
- Significantly reduced GPU work while the dashboard is open and idle, and zero background CPU/GPU work while it's closed.
- Fixed a real calendar sync loop for useVdirsyncer users.
- The dashboard widget tree stays resident in memory after login (one-time build cost moved from "first open" to shell startup) and its services (Weather, GitHub, Calendar, ToDo) do their initial network/file work at login instead of on first open.

## Before

https://github.com/user-attachments/assets/3bcccd5a-0f70-4b49-95bb-baaaff2e5e74

## After

https://github.com/user-attachments/assets/a41aac3c-b5f7-4726-9a46-1e1e5561ea82