### PR TITLE
Transparency Fix

### DIFF
--- a/src/share/sleex/settings.qml
+++ b/src/share/sleex/settings.qml
@@ -55,6 +55,8 @@ ApplicationWindow {
 
     onClosing: Qt.quit()
 
+    AppearanceBridge {} // Init the bridge to populate the Appearance singleton
+
     Component.onCompleted: {
         MaterialThemeLoader.reapplyTheme()
         Idle.init()


### PR DESCRIPTION
# Transparency Fix

### Root cause:

 `settings.qml` runs as its own process (`qs -p .../settings.qml`) and never instantiated `AppearanceBridge`, which is the only thing that pushes `Config.options.appearance.transparency/opacity` into the Appearance singleton. Without it `backgroundTransparency/contentTransparency` stay 0, so `ColorsGroup::recompute()` renders every color fully opaque

### Fix:

Added `AppearanceBridge {}` to `Settings.qml`.

### Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f8be9a5b-4e29-4bdd-83e5-38de974b4a75" />

 ### After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5e9fd564-b723-4136-9c53-6c268b94b27c" />
