### PR TITLE
Fix network status after sleep

### DIFF
--- a/src/share/sleex/modules/dashboard/home/HomeGithubWidget.qml
+++ b/src/share/sleex/modules/dashboard/home/HomeGithubWidget.qml
@@ -31,16 +31,24 @@ Rectangle {
             anchors.horizontalCenter: parent.horizontalCenter
         }
 
-        Loader {
-            active: root.connected
+        Item {
+            width: 358
+            height: 61
             anchors.horizontalCenter: parent.horizontalCenter
-            sourceComponent: GhCalendar {}
-        }
 
-        Loader {
-            active: !root.connected
-            anchors.horizontalCenter: parent.horizontalCenter
-            sourceComponent: GhCalendarNoNet {}
+            Loader {
+                anchors.fill: parent
+                active: true
+                visible: root.connected
+                sourceComponent: GhCalendar {}
+            }
+
+            Loader {
+                anchors.fill: parent
+                active: true
+                visible: !root.connected
+                sourceComponent: GhCalendarNoNet {}
+            }
         }
 
         Text {

--- a/src/share/sleex/plugins/src/Sleex/services/CMakeLists.txt
+++ b/src/share/sleex/plugins/src/Sleex/services/CMakeLists.txt
@@ -33,4 +33,5 @@ target_link_libraries(sleex-services
         Qt6::Core
         Qt6::Qml
         Qt6::Bluetooth
+        Qt6::DBus
 )

--- a/src/share/sleex/plugins/src/Sleex/services/network.cpp
+++ b/src/share/sleex/plugins/src/Sleex/services/network.cpp
@@ -10,6 +10,7 @@
 #include <QFile>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QDBusConnection>
 
 namespace sleex::services {
 
@@ -197,6 +198,8 @@ Network::Network(QObject *parent)
         if (hasActiveConnection()) fetchNetworkInfo();
     });
     if (hasActiveConnection()) fetchNetworkInfo();
+
+    registerSleepSignals();
 }
 
 Network::~Network() {
@@ -252,11 +255,16 @@ QString Network::getNetworkIcon(int strength) {
 }
 
 QString Network::getWifiIcon() {
-    if (!m_wifiEnabled)
-        return "signal_wifi_off";
+    if (m_wifiDevice) {
+        if (nm_device_get_state(NM_DEVICE(m_wifiDevice)) == NM_DEVICE_STATE_ACTIVATED) {
+            if (NMAccessPoint *ap = nm_device_wifi_get_active_access_point(m_wifiDevice))
+                return strengthToIcon(nm_access_point_get_strength(ap));
+            return strengthToIcon(m_active ? m_active->strength() : 100);
+        }
+    }
 
-    if (m_active && m_active->active())
-        return strengthToIcon(m_active->strength());
+    if (m_ethernet)
+        return "lan";
 
     return "signal_wifi_off";
 }
@@ -491,10 +499,14 @@ void Network::onAccessPointRemoved(NMDeviceWifi*, NMAccessPoint*, gpointer user_
     static_cast<Network*>(user_data)->updateNetworks();
 }
 void Network::onDeviceAdded(NMClient*, NMDevice*, gpointer user_data) {
-    static_cast<Network*>(user_data)->updateEthernetStatus();
+    auto *self = static_cast<Network*>(user_data);
+    self->refreshWifiDevice();
+    self->updateEthernetStatus();
 }
 void Network::onDeviceRemoved(NMClient*, NMDevice*, gpointer user_data) {
-    static_cast<Network*>(user_data)->updateEthernetStatus();
+    auto *self = static_cast<Network*>(user_data);
+    self->refreshWifiDevice();
+    self->updateEthernetStatus();
 }
 void Network::onConnectionAdded(NMClient*, NMRemoteConnection*, gpointer user_data) {
     static_cast<Network*>(user_data)->updateKnownNetworks();
@@ -690,6 +702,69 @@ void Network::updateActiveConnection() {
     }
 
     emit wifiIconChanged();
+}
+
+void Network::registerSleepSignals() {
+    QDBusConnection bus = QDBusConnection::systemBus();
+    if (!bus.isConnected()) {
+        qWarning() << "Network: not connected to the system D-Bus;"
+                      " sleep/resume refresh is disabled";
+        return;
+    }
+
+    if (!bus.connect(QStringLiteral("org.freedesktop.login1"),
+                     QStringLiteral("/org/freedesktop/login1"),
+                     QStringLiteral("org.freedesktop.login1.Manager"),
+                     QStringLiteral("PrepareForSleep"),
+                     this, SLOT(onPrepareForSleep(bool)))) {
+        qWarning() << "Network: failed to subscribe to logind PrepareForSleep;"
+                      " sleep/resume refresh is disabled";
+    }
+}
+
+void Network::onPrepareForSleep(bool sleeping) {
+    if (sleeping) return;
+
+    qDebug() << "Network: wakeup detected, re-syncing network state";
+
+    refreshAfterResume();
+    QTimer::singleShot(2000, this, [this]() { refreshAfterResume(); });
+    QTimer::singleShot(5000, this, [this]() { refreshAfterResume(); });
+}
+
+void Network::refreshAfterResume() {
+    const bool enabled = nm_client_wireless_get_enabled(m_client);
+    if (m_wifiEnabled != enabled) { m_wifiEnabled = enabled; emit wifiEnabledChanged(); }
+
+    refreshWifiDevice();
+    updateEthernetStatus();
+    updateKnownNetworks();
+    updateNetworks();
+    updateActiveConnection();
+    emit hasActiveConnectionChanged();
+
+    if (hasActiveConnection()) fetchNetworkInfo();
+}
+
+void Network::refreshWifiDevice() {
+    NMDeviceWifi *dev = getPrimaryWifiDevice();
+    if (dev == m_wifiDevice) return;
+
+    if (m_wifiDevice) {
+        if (m_apAddedId)           g_signal_handler_disconnect(m_wifiDevice, m_apAddedId);
+        if (m_apRemovedId)         g_signal_handler_disconnect(m_wifiDevice, m_apRemovedId);
+        if (m_deviceStateChangedId)g_signal_handler_disconnect(m_wifiDevice, m_deviceStateChangedId);
+        m_apAddedId = m_apRemovedId = m_deviceStateChangedId = 0;
+    }
+
+    m_wifiDevice = dev;
+    if (!m_wifiDevice) return;
+
+    m_apAddedId = g_signal_connect(m_wifiDevice, "access-point-added",   G_CALLBACK(onAccessPointAdded),   this);
+    m_apRemovedId = g_signal_connect(m_wifiDevice, "access-point-removed", G_CALLBACK(onAccessPointRemoved), this);
+    m_deviceStateChangedId = g_signal_connect(m_wifiDevice, "notify::state", G_CALLBACK(onDeviceStateChanged), this);
+
+    updateActiveConnection();
 }
 
 void Network::updateKnownNetworks() {

--- a/src/share/sleex/plugins/src/Sleex/services/network.cpp
+++ b/src/share/sleex/plugins/src/Sleex/services/network.cpp
@@ -10,7 +10,6 @@
 #include <QFile>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QDBusConnection>
 
 namespace sleex::services {
 
@@ -150,7 +149,8 @@ Network::Network(QObject *parent)
       m_connectingToSsid(""),
       m_apAddedId(0), m_apRemovedId(0), m_deviceAddedId(0), m_deviceRemovedId(0),
       m_wirelessEnabledId(0), m_activeConnectionsId(0),
-      m_connectionAddedId(0), m_connectionRemovedId(0), m_deviceStateChangedId(0)
+      m_connectionAddedId(0), m_connectionRemovedId(0), m_deviceStateChangedId(0),
+      m_clientStateChangedId(0)
 {
     GError *error = nullptr;
     m_client = nm_client_new(nullptr, &error);
@@ -168,6 +168,7 @@ Network::Network(QObject *parent)
     m_activeConnectionsId  = g_signal_connect(m_client, "notify::active-connections",    G_CALLBACK(onActiveConnectionsChanged), this);
     m_connectionAddedId    = g_signal_connect(m_client, "connection-added",              G_CALLBACK(onConnectionAdded),          this);
     m_connectionRemovedId  = g_signal_connect(m_client, "connection-removed",            G_CALLBACK(onConnectionRemoved),        this);
+    m_clientStateChangedId = g_signal_connect(m_client, "notify::state",                G_CALLBACK(onClientStateChanged),       this);
 
     if (m_wifiDevice) {
         m_apAddedId          = g_signal_connect(m_wifiDevice, "access-point-added",   G_CALLBACK(onAccessPointAdded),   this);
@@ -198,8 +199,6 @@ Network::Network(QObject *parent)
         if (hasActiveConnection()) fetchNetworkInfo();
     });
     if (hasActiveConnection()) fetchNetworkInfo();
-
-    registerSleepSignals();
 }
 
 Network::~Network() {
@@ -212,6 +211,7 @@ Network::~Network() {
     if (m_activeConnectionsId) g_signal_handler_disconnect(m_client, m_activeConnectionsId);
     if (m_connectionAddedId)   g_signal_handler_disconnect(m_client, m_connectionAddedId);
     if (m_connectionRemovedId) g_signal_handler_disconnect(m_client, m_connectionRemovedId);
+    if (m_clientStateChangedId) g_signal_handler_disconnect(m_client, m_clientStateChangedId);
 
     qDeleteAll(m_networks);
     if (m_client) g_object_unref(m_client);
@@ -255,16 +255,11 @@ QString Network::getNetworkIcon(int strength) {
 }
 
 QString Network::getWifiIcon() {
-    if (m_wifiDevice) {
-        if (nm_device_get_state(NM_DEVICE(m_wifiDevice)) == NM_DEVICE_STATE_ACTIVATED) {
-            if (NMAccessPoint *ap = nm_device_wifi_get_active_access_point(m_wifiDevice))
-                return strengthToIcon(nm_access_point_get_strength(ap));
-            return strengthToIcon(m_active ? m_active->strength() : 100);
-        }
-    }
+    if (!m_wifiEnabled)
+        return "signal_wifi_off";
 
-    if (m_ethernet)
-        return "lan";
+    if (m_active && m_active->active())
+        return strengthToIcon(m_active->strength());
 
     return "signal_wifi_off";
 }
@@ -395,40 +390,42 @@ void Network::forgetNetwork(const QString &ssid) {
 }
 
 
-// after a successful async initiation. Schedules staged checks.
+// after a successful async initiation. Uses NMDevice state signals instead of timers.
 void Network::scheduleConnectionVerification(const QString &ssid) {
-    // Stage 1 – quick check at 1 s (catches immediate failures)
-    QTimer::singleShot(1000, this, [this, ssid]() {
-        if (!m_wifiDevice) return;
+    if (!m_wifiDevice) return;
 
-        NMDeviceState       state  = nm_device_get_state(NM_DEVICE(m_wifiDevice));
-        NMDeviceStateReason reason = nm_device_get_state_reason(NM_DEVICE(m_wifiDevice));
+    NMDeviceState       state  = nm_device_get_state(NM_DEVICE(m_wifiDevice));
+    NMDeviceStateReason reason = nm_device_get_state_reason(NM_DEVICE(m_wifiDevice));
 
-        bool immediateFailure =
-            state == NM_DEVICE_STATE_FAILED       ||
-            state == NM_DEVICE_STATE_NEED_AUTH    ||
-            state == NM_DEVICE_STATE_DISCONNECTED ||
-            reason == NM_DEVICE_STATE_REASON_NO_SECRETS              ||
-            reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT    ||
-            reason == NM_DEVICE_STATE_REASON_SUPPLICANT_CONFIG_FAILED ||
-            reason == NM_DEVICE_STATE_REASON_SUPPLICANT_TIMEOUT;
+    // Already activated – finalize immediately
+    if (state == NM_DEVICE_STATE_ACTIVATED) {
+        finalizeConnectionResult(ssid);
+        return;
+    }
 
-        if (immediateFailure) {
-            QString msg = (reason == NM_DEVICE_STATE_REASON_SUPPLICANT_TIMEOUT)
-                        ? "Connection timeout - likely incorrect password"
-                        : "Incorrect password";
-            markConnectionFailed(ssid);
-            emit connectionFailed(ssid, msg);
-            updateNetworks();
-            updateActiveConnection();
-            return;
-        }
+    // Immediate failure – fail now
+    bool immediateFailure =
+        state == NM_DEVICE_STATE_FAILED       ||
+        state == NM_DEVICE_STATE_NEED_AUTH    ||
+        state == NM_DEVICE_STATE_DISCONNECTED ||
+        reason == NM_DEVICE_STATE_REASON_NO_SECRETS              ||
+        reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT    ||
+        reason == NM_DEVICE_STATE_REASON_SUPPLICANT_CONFIG_FAILED ||
+        reason == NM_DEVICE_STATE_REASON_SUPPLICANT_TIMEOUT;
 
-        // Stage 2 – definitive check at 3 s (1 s + 2 s)
-        QTimer::singleShot(2000, this, [this, ssid]() {
-            finalizeConnectionResult(ssid);
-        });
-    });
+    if (immediateFailure) {
+        QString msg = (reason == NM_DEVICE_STATE_REASON_SUPPLICANT_TIMEOUT)
+                    ? "Connection timeout - likely incorrect password"
+                    : "Incorrect password";
+        markConnectionFailed(ssid);
+        emit connectionFailed(ssid, msg);
+        updateNetworks();
+        updateActiveConnection();
+        return;
+    }
+
+    // Pending – wait for onDeviceStateChanged to call finalizeConnectionResult
+    m_pendingVerificationSsid = ssid;
 }
 
 void Network::finalizeConnectionResult(const QString &ssid) {
@@ -499,14 +496,10 @@ void Network::onAccessPointRemoved(NMDeviceWifi*, NMAccessPoint*, gpointer user_
     static_cast<Network*>(user_data)->updateNetworks();
 }
 void Network::onDeviceAdded(NMClient*, NMDevice*, gpointer user_data) {
-    auto *self = static_cast<Network*>(user_data);
-    self->refreshWifiDevice();
-    self->updateEthernetStatus();
+    static_cast<Network*>(user_data)->updateEthernetStatus();
 }
 void Network::onDeviceRemoved(NMClient*, NMDevice*, gpointer user_data) {
-    auto *self = static_cast<Network*>(user_data);
-    self->refreshWifiDevice();
-    self->updateEthernetStatus();
+    static_cast<Network*>(user_data)->updateEthernetStatus();
 }
 void Network::onConnectionAdded(NMClient*, NMRemoteConnection*, gpointer user_data) {
     static_cast<Network*>(user_data)->updateKnownNetworks();
@@ -527,6 +520,18 @@ void Network::onWirelessEnabledChanged(GObject*, GParamSpec*, gpointer user_data
 
 void Network::onActiveConnectionsChanged(GObject*, GParamSpec*, gpointer user_data) {
     static_cast<Network*>(user_data)->updateActiveConnection();
+}
+
+void Network::onClientStateChanged(GObject*, GParamSpec*, gpointer user_data) {
+    auto *self = static_cast<Network*>(user_data);
+    NMState state = nm_client_get_state(self->m_client);
+
+    if (state == NM_STATE_CONNECTED_GLOBAL || state == NM_STATE_CONNECTED_SITE) {
+        self->updateNetworks();
+        self->updateEthernetStatus();
+        self->updateActiveConnection();
+        self->fetchNetworkInfo();
+    }
 }
 
 void Network::onScanDone(GObject*, GAsyncResult *result, gpointer user_data) {
@@ -704,69 +709,6 @@ void Network::updateActiveConnection() {
     emit wifiIconChanged();
 }
 
-void Network::registerSleepSignals() {
-    QDBusConnection bus = QDBusConnection::systemBus();
-    if (!bus.isConnected()) {
-        qWarning() << "Network: not connected to the system D-Bus;"
-                      " sleep/resume refresh is disabled";
-        return;
-    }
-
-    if (!bus.connect(QStringLiteral("org.freedesktop.login1"),
-                     QStringLiteral("/org/freedesktop/login1"),
-                     QStringLiteral("org.freedesktop.login1.Manager"),
-                     QStringLiteral("PrepareForSleep"),
-                     this, SLOT(onPrepareForSleep(bool)))) {
-        qWarning() << "Network: failed to subscribe to logind PrepareForSleep;"
-                      " sleep/resume refresh is disabled";
-    }
-}
-
-void Network::onPrepareForSleep(bool sleeping) {
-    if (sleeping) return;
-
-    qDebug() << "Network: wakeup detected, re-syncing network state";
-
-    refreshAfterResume();
-    QTimer::singleShot(2000, this, [this]() { refreshAfterResume(); });
-    QTimer::singleShot(5000, this, [this]() { refreshAfterResume(); });
-}
-
-void Network::refreshAfterResume() {
-    const bool enabled = nm_client_wireless_get_enabled(m_client);
-    if (m_wifiEnabled != enabled) { m_wifiEnabled = enabled; emit wifiEnabledChanged(); }
-
-    refreshWifiDevice();
-    updateEthernetStatus();
-    updateKnownNetworks();
-    updateNetworks();
-    updateActiveConnection();
-    emit hasActiveConnectionChanged();
-
-    if (hasActiveConnection()) fetchNetworkInfo();
-}
-
-void Network::refreshWifiDevice() {
-    NMDeviceWifi *dev = getPrimaryWifiDevice();
-    if (dev == m_wifiDevice) return;
-
-    if (m_wifiDevice) {
-        if (m_apAddedId)           g_signal_handler_disconnect(m_wifiDevice, m_apAddedId);
-        if (m_apRemovedId)         g_signal_handler_disconnect(m_wifiDevice, m_apRemovedId);
-        if (m_deviceStateChangedId)g_signal_handler_disconnect(m_wifiDevice, m_deviceStateChangedId);
-        m_apAddedId = m_apRemovedId = m_deviceStateChangedId = 0;
-    }
-
-    m_wifiDevice = dev;
-    if (!m_wifiDevice) return;
-
-    m_apAddedId = g_signal_connect(m_wifiDevice, "access-point-added",   G_CALLBACK(onAccessPointAdded),   this);
-    m_apRemovedId = g_signal_connect(m_wifiDevice, "access-point-removed", G_CALLBACK(onAccessPointRemoved), this);
-    m_deviceStateChangedId = g_signal_connect(m_wifiDevice, "notify::state", G_CALLBACK(onDeviceStateChanged), this);
-
-    updateActiveConnection();
-}
-
 void Network::updateKnownNetworks() {
     m_knownSsids.clear();
     const GPtrArray *conns = nm_client_get_connections(m_client);
@@ -830,28 +772,8 @@ void Network::emitConnectionSucceededWithVerification(const QString &ssid) {
     m_authErrorEmitted.removeAll(ssid);
     emit connectionSucceeded(ssid);
     emit wifiIconChanged();
-    QTimer::singleShot(5000, this, [this, ssid]() { verifyDelayedConnection(ssid); });
-}
-
-void Network::verifyDelayedConnection(const QString &ssid) {
-    bool ok = false;
-    QString errorMsg = "Incorrect password";
-
-    if (m_wifiDevice && nm_device_get_state(NM_DEVICE(m_wifiDevice)) == NM_DEVICE_STATE_ACTIVATED) {
-        if (NMAccessPoint *ap = nm_device_wifi_get_active_access_point(m_wifiDevice)) {
-            gsize sz;
-            const char *d = (const char*)g_bytes_get_data(nm_access_point_get_ssid(ap), &sz);
-            ok = d && QString::fromUtf8(d, sz) == ssid;
-        }
-    }
-
-    qDebug() << "5s verification for" << ssid << "- ok:" << ok;
-    if (!ok) {
-        emit connectionFailed(ssid, errorMsg);
-        emit wifiIconChanged();
-        updateNetworks();
-        updateActiveConnection();
-    }
+    updateNetworks();
+    updateActiveConnection();
 }
 
 void Network::onDeviceStateChanged(GObject*, GParamSpec*, gpointer user_data) {
@@ -860,6 +782,33 @@ void Network::onDeviceStateChanged(GObject*, GParamSpec*, gpointer user_data) {
 
     NMDeviceState       state  = nm_device_get_state(NM_DEVICE(self->m_wifiDevice));
     NMDeviceStateReason reason = nm_device_get_state_reason(NM_DEVICE(self->m_wifiDevice));
+
+    // If we have a pending connection verification, finalize on terminal states
+    if (!self->m_pendingVerificationSsid.isEmpty()) {
+        if (state == NM_DEVICE_STATE_ACTIVATED) {
+            QString ssid = self->m_pendingVerificationSsid;
+            self->m_pendingVerificationSsid.clear();
+            self->finalizeConnectionResult(ssid);
+            return;
+        }
+        if (state == NM_DEVICE_STATE_FAILED       ||
+            state == NM_DEVICE_STATE_DISCONNECTED ||
+            state == NM_DEVICE_STATE_NEED_AUTH) {
+            bool authRelated =
+                reason == NM_DEVICE_STATE_REASON_NO_SECRETS              ||
+                reason == NM_DEVICE_STATE_REASON_SUPPLICANT_DISCONNECT    ||
+                reason == NM_DEVICE_STATE_REASON_SUPPLICANT_CONFIG_FAILED ||
+                reason == NM_DEVICE_STATE_REASON_SUPPLICANT_TIMEOUT;
+            QString ssid = self->m_pendingVerificationSsid;
+            self->m_pendingVerificationSsid.clear();
+            QString msg = authRelated ? "Incorrect password" : "Connection failed";
+            self->markConnectionFailed(ssid);
+            emit self->connectionFailed(ssid, msg);
+            self->updateNetworks();
+            self->updateActiveConnection();
+            return;
+        }
+    }
 
     bool authFailure =
         (state == NM_DEVICE_STATE_FAILED       ||

--- a/src/share/sleex/plugins/src/Sleex/services/network.hpp
+++ b/src/share/sleex/plugins/src/Sleex/services/network.hpp
@@ -193,6 +193,7 @@ public:
 
 private slots:
     void verifyDelayedConnection(const QString &ssid);
+    void onPrepareForSleep(bool sleeping);
 
 private:
     void scheduleConnectionVerification(const QString &ssid);
@@ -296,6 +297,9 @@ private:
     
     void updateEthernetStatus();
     void updateKnownNetworks();
+    void refreshAfterResume();
+    void refreshWifiDevice();
+    void registerSleepSignals();
     AccessPoint* findAccessPoint(NMAccessPoint *ap);
     NMDeviceWifi* getPrimaryWifiDevice();
     NMRemoteConnection* findConnectionForSsid(const QString &ssid);

--- a/src/share/sleex/plugins/src/Sleex/services/network.hpp
+++ b/src/share/sleex/plugins/src/Sleex/services/network.hpp
@@ -191,10 +191,6 @@ public:
     Q_INVOKABLE void generateQrCode(const QString &ssid, const QString &securityStr);
     Q_INVOKABLE void clearQrCode();
 
-private slots:
-    void verifyDelayedConnection(const QString &ssid);
-    void onPrepareForSleep(bool sleeping);
-
 private:
     void scheduleConnectionVerification(const QString &ssid);
     void finalizeConnectionResult(const QString &ssid);
@@ -293,13 +289,11 @@ private:
     static void onConnectionAdded(NMClient *client, NMRemoteConnection *connection, gpointer user_data);
     static void onConnectionRemoved(NMClient *client, NMRemoteConnection *connection, gpointer user_data);
     static void onDeviceStateChanged(GObject *object, GParamSpec *pspec, gpointer user_data);
+    static void onClientStateChanged(GObject *object, GParamSpec *pspec, gpointer user_data);
     static void onWifiEnabledSet(GObject *source, GAsyncResult *result, gpointer user_data);
     
     void updateEthernetStatus();
     void updateKnownNetworks();
-    void refreshAfterResume();
-    void refreshWifiDevice();
-    void registerSleepSignals();
     AccessPoint* findAccessPoint(NMAccessPoint *ap);
     NMDeviceWifi* getPrimaryWifiDevice();
     NMRemoteConnection* findConnectionForSsid(const QString &ssid);
@@ -315,6 +309,7 @@ private:
     QString m_connectingToSsid;
     QStringList m_failedConnections; // Track SSIDs with authentication failures
     QStringList m_authErrorEmitted; // Track SSIDs that have already emitted auth errors
+    QString m_pendingVerificationSsid; // SSID waiting for signal-based connection verification
     
     gulong m_apAddedId;
     gulong m_apRemovedId;
@@ -325,6 +320,7 @@ private:
     gulong m_connectionAddedId;
     gulong m_connectionRemovedId;
     gulong m_deviceStateChangedId;
+    gulong m_clientStateChangedId;
 
     // --- Ported from Network.qml ---
     QTimer m_errorTimer;


### PR DESCRIPTION
# Fix network status after sleep

This bug has existed for a while now. When the system wakes up after going to sleep, the network symbol in the bar shows that there is no network/network is disconnected - even though there is a network connection. The dashboard widgets also falsely believed this. This PR fixes that bug.

# Before
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/f8d2c8c6-f877-4581-bc53-5ae0a634710d" />
<img width="1920" alt="Pasted image" src="https://github.com/user-attachments/assets/03b3f830-f501-42f9-806d-00430aae791c" />

# After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6a514e4b-88ee-41c9-a34d-873335fccb25" />
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/8a279a6e-c696-4d84-97f4-a29653c01275" />
